### PR TITLE
Fix error message when issuing device token and rename device endpoints

### DIFF
--- a/backend/dials/cern_auth/serializers.py
+++ b/backend/dials/cern_auth/serializers.py
@@ -34,3 +34,8 @@ class DeviceTokenSerializer(serializers.Serializer):
     token_type = serializers.CharField()
     session_state = serializers.CharField()
     scope = serializers.CharField()
+
+
+class PendingAuthorizationErrorSerializer(serializers.Serializer):
+    detail = serializers.CharField()
+    code = serializers.CharField()

--- a/backend/dials/cern_auth/viewsets.py
+++ b/backend/dials/cern_auth/viewsets.py
@@ -1,8 +1,10 @@
+import json
 import logging
 
 from django.conf import settings
 from django.http import HttpResponseBadRequest
 from drf_spectacular.utils import extend_schema
+from keycloak.exceptions import KeycloakPostError
 from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -14,6 +16,7 @@ from .serializers import (
     DeviceSerializer,
     DeviceTokenSerializer,
     ExchangedTokenSerializer,
+    PendingAuthorizationErrorSerializer,
     SubjectTokenSerializer,
 )
 
@@ -51,7 +54,7 @@ class AuthViewSet(ViewSet):
         detail=False,
         methods=["get"],
         name="Issue device code",
-        url_path=r"device",
+        url_path=r"new-device",
     )
     def get_device(self, request: Request):
         issue_device = confidential_kc.get_device()
@@ -60,19 +63,29 @@ class AuthViewSet(ViewSet):
 
     @extend_schema(
         request=DeviceCodeSerializer,
-        responses={200: DeviceTokenSerializer},
+        responses={200: DeviceTokenSerializer, 400: PendingAuthorizationErrorSerializer},
     )
     @action(
         detail=False,
         methods=["post"],
         name="Verify if device code was authenticate and issue token",
-        url_path=r"token-from-device",
+        url_path=r"device-token",
     )
     def issue_device_token(self, request: Request):
         device_code = request.data.get("device_code")
         if not device_code:
             return HttpResponseBadRequest("Attribute 'device_code' not found in request body.")
 
-        token = confidential_kc.issue_device_token(device_code=device_code)
-        payload = DeviceTokenSerializer(token).data
-        return Response(payload)
+        try:
+            token = confidential_kc.issue_device_token(device_code=device_code)
+        except KeycloakPostError as err:
+            err_msg = json.loads(err.error_message.decode("utf-8"))
+            if err_msg.get("error") != "authorization_pending":
+                raise err
+            payload = PendingAuthorizationErrorSerializer(err_msg).data
+            response = Response(payload, status=err.response_code)
+        else:
+            payload = DeviceTokenSerializer(token).data
+            response = Response(payload)
+
+        return response


### PR DESCRIPTION
* Return appropriate error message and code when user tries to issue device token with authorization still pending
* Rename `token-from-device` endpoint to `device-token`
* Rename `device` endpoint to `new-device`