### PR TITLE
Authentication changes and selected MEs from CMSSW

### DIFF
--- a/backend/dials/cern_auth/viewsets.py
+++ b/backend/dials/cern_auth/viewsets.py
@@ -9,11 +9,8 @@ from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
-from utils.rest_framework_cern_sso.authentication import (
-    CERNKeycloakConfidentialAuthentication,
-    CERNKeycloakPublicAuthentication,
-    confidential_kc,
-)
+from utils.rest_framework_cern_sso.authentication import CERNKeycloakPublicAuthentication, confidential_kc
+from utils.rest_framework_cern_sso.user import CERNKeycloakUser
 
 from .serializers import (
     DeviceCodeSerializer,
@@ -46,7 +43,7 @@ class AuthViewSet(ViewSet):
         if not subject_token:
             return HttpResponseBadRequest("Attribute 'subject_token' not found in request body.")
 
-        user = request.user
+        user: CERNKeycloakUser = request.user
         confidential_token = user.token.client.exchange_token(subject_token, settings.KEYCLOAK_CONFIDENTIAL_CLIENT_ID)
         payload = ExchangedTokenSerializer(confidential_token).data
         return Response(payload)
@@ -55,20 +52,13 @@ class AuthViewSet(ViewSet):
         request=RefreshTokenSerializer,
         responses={200: DeviceTokenSerializer},
     )
-    @action(
-        detail=False,
-        methods=["post"],
-        name="Refresh confidential token",
-        url_path=r"refresh-token",
-        authentication_classes=[CERNKeycloakConfidentialAuthentication],
-    )
+    @action(detail=False, methods=["post"], name="Refresh confidential token", url_path=r"refresh-token")
     def refresh_token(self, request: Request):
         ref_token = request.data.get("refresh_token")
         if not ref_token:
             return HttpResponseBadRequest("Attribute 'refresh_token' not found in request body.")
 
-        user = request.user
-        confidential_token = user.token.client.refresh_token(ref_token)
+        confidential_token = confidential_kc.refresh_token(ref_token)
         payload = DeviceTokenSerializer(confidential_token).data
         return Response(payload)
 

--- a/backend/dials/dials/dqmio_perls_mes.py
+++ b/backend/dials/dials/dqmio_perls_mes.py
@@ -1,0 +1,34 @@
+import re
+from typing import List
+
+import requests
+
+URL = "https://github.com/cms-sw/cmssw/raw/master/DQMServices/Core/python/nanoDQMIO_perLSoutput_cff.py"
+STARTS_STR = "vstring(*("
+ENDS_STR = ")))"
+
+
+def _get_cmssw_script() -> str:
+    req = requests.get(URL)
+    req.raise_for_status()
+    return req.text
+
+
+def _std_script_text(text: str) -> str:
+    text = text.strip().replace("\n", "")
+    return re.sub(r"\s+", "", text)
+
+
+def _extract_mes(text: str) -> List:
+    starts = text.index(STARTS_STR) + len(STARTS_STR)
+    ends = text.index(ENDS_STR)
+    mes = text[starts:ends].split(",")
+    mes = [me.replace('"', "") for me in mes]
+    mes = [me for me in mes if me != ""]
+    return mes
+
+
+def get_monitoring_elements_names() -> List:
+    text = _get_cmssw_script()
+    text = _std_script_text(text)
+    return _extract_mes(text)

--- a/backend/dials/dials/settings.py
+++ b/backend/dials/dials/settings.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from celery.schedules import crontab
 from dotenv import load_dotenv
 
+from .dqmio_perls_mes import get_monitoring_elements_names
+
 load_dotenv()
 
 # Discover which environment the server is running
@@ -199,6 +201,9 @@ CELERY_BROKER_TRANSPORT_OPTIONS = {"visibility_timeout": 60 * 60 * 24 * 2}  # se
 
 # Path used in dqmio_file_indexer app to discover DQMIO files
 DIR_PATH_DQMIO_STORAGE = os.getenv("DJANGO_DQMIO_STORAGE")
+
+# List of MEs to ingest
+DQMIO_MES_TO_INGEST = get_monitoring_elements_names()
 
 # Keycloak OIDC config
 KEYCLOAK_SERVER_URL = os.getenv("DJANGO_KEYCLOAK_SERVER_URL")

--- a/backend/dials/dqmio_etl/reader.py
+++ b/backend/dials/dqmio_etl/reader.py
@@ -12,6 +12,7 @@ import logging
 from collections import defaultdict, namedtuple
 from fnmatch import fnmatch
 from multiprocessing.pool import ThreadPool
+from typing import List, Optional
 
 import ROOT
 
@@ -222,7 +223,7 @@ class DQMIOReader:
 
         return result
 
-    def count_mes(self, me_selection=(3, 4, 5, 6, 7, 8)):
+    def count_mes(self, whitelist_mes: Optional[List] = None, me_selection=(3, 4, 5, 6, 7, 8)):
         """
         Count how many monitoring elements exists given ME selection
         """
@@ -230,6 +231,8 @@ class DQMIOReader:
         for run, lumi in self.list_lumis():
             melist = self.get_mes_for_lumi(run, lumi, "*")
             for me in melist:
+                if whitelist_mes and me.name not in whitelist_mes:
+                    continue
                 if me.type in me_selection:
                     num_total_entries += 1
         return num_total_entries

--- a/backend/dials/dqmio_etl/serializers.py
+++ b/backend/dials/dqmio_etl/serializers.py
@@ -49,3 +49,7 @@ class RunLumisectionsSerializer(serializers.Serializer):
     hist2d_count = serializers.IntegerField()
     int_lumi = serializers.IntegerField()
     oms_zerobias_rate = serializers.IntegerField()
+
+
+class MEsSerializer(serializers.Serializer):
+    mes = serializers.ListSerializer(child=serializers.CharField())

--- a/backend/dials/dqmio_etl/viewsets.py
+++ b/backend/dials/dqmio_etl/viewsets.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.db.models import Count, F, TextField, Value
 from django.http import HttpResponseBadRequest
 from django_filters.rest_framework import DjangoFilterBackend
@@ -22,6 +23,7 @@ from .serializers import (
     LumisectionHistogramsIngestionInputSerializer,
     LumisectionHistogramsSubsystemCountSerializer,
     LumisectionSerializer,
+    MEsSerializer,
     RunLumisectionsSerializer,
     RunSerializer,
 )
@@ -107,6 +109,20 @@ class LumisectionViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin, views
         task = TaskResponseBase(id=task.id, state=task.state, ready=task.ready())
         task = TaskResponseSerializer(task)
         return Response(task.data)
+
+    @extend_schema(
+        request=None,
+        responses={200: MEsSerializer},
+    )
+    @action(
+        detail=False,
+        methods=["get"],
+        name="List filtered MEs during ETL",
+        url_path=r"configured-mes",
+    )
+    def configured_mes(self, request):
+        payload = MEsSerializer({"mes": settings.DQMIO_MES_TO_INGEST})
+        return Response(payload.data)
 
 
 class LumisectionHistogram1DViewSet(mixins.RetrieveModelMixin, mixins.ListModelMixin, viewsets.GenericViewSet):

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1869,4 +1869,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "493019e7edb9252da0a0483d7af1206d4e1613b96184d387247dca6f4f54f385"
+content-hash = "a20dbc0e354bcd21592ffaee7384422b01e997cc31df204db77c7cd726f231e8"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ python-keycloak = "^3.7.0"
 python-dotenv = "^1.0.1"
 uvicorn = "^0.27.0.post1"
 gunicorn = "^21.2.0"
+requests = "^2.31.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.0"


### PR DESCRIPTION
* refactor: catch ExpiredSignatureError when validating bearer token and raise AuthenticatorFailed error instead
* refactor: do not validate access token using CERNKeycloakConfidentialAuthentication in refresh-token endpoint
* refactor: ingest only selected MEs describe in cmssw nanoDQMIO_perLSoutput_cff
* feat: add `configured-mes` endpoint to `LumisectionViewSet` to inspect list of selected MEs in application runtime