### PR TITLE
Raise bad request when excluding filters are used simultaneously

### DIFF
--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/backend/dials/dqmio_etl/filters.py
+++ b/backend/dials/dqmio_etl/filters.py
@@ -1,4 +1,5 @@
 from django_filters import rest_framework as filters
+from rest_framework.exceptions import ParseError
 
 from .models import Lumisection, LumisectionHistogram1D, LumisectionHistogram2D, Run
 
@@ -18,6 +19,19 @@ class LumisectionFilter(filters.FilterSet):
     max_ls_number = filters.NumberFilter(label="Maximum lumisection number", field_name="ls_number", lookup_expr="lte")
     min_run_number = filters.NumberFilter(label="Minimum run number", field_name="run_id", lookup_expr="gte")
     max_run_number = filters.NumberFilter(label="Maximum run number", field_name="run_id", lookup_expr="lte")
+
+    def filter_queryset(self, queryset, *args, **kwargs):
+        queryset = super().filter_queryset(queryset, *args, **kwargs)
+        cleaned_data = {key: value for key, value in self.form.cleaned_data.items() if value is not None}
+
+        run_number_used = "run_number" in cleaned_data
+        min_run_number_used = "min_run_number" in cleaned_data
+        max_run_number_used = "max_run_number" in cleaned_data
+
+        if run_number_used and (min_run_number_used or max_run_number_used):
+            raise ParseError("run number and range run number filter cannot be used together.")
+
+        return queryset
 
     class Meta:
         model = Lumisection
@@ -39,6 +53,39 @@ class LumisectionHistogram1DFilter(filters.FilterSet):
     )
     title_contains = filters.CharFilter(label="Title contains", field_name="title", lookup_expr="contains")
     min_entries = filters.NumberFilter(label="Minimum number of entries", field_name="entries", lookup_expr="gte")
+
+    def filter_queryset(self, queryset, *args, **kwargs):
+        queryset = super().filter_queryset(queryset, *args, **kwargs)
+        cleaned_data = {key: value for key, value in self.form.cleaned_data.items() if value is not None}
+
+        run_number_used = "run_number" in cleaned_data
+        min_run_number_used = "min_run_number" in cleaned_data
+        max_run_number_used = "max_run_number" in cleaned_data
+
+        if run_number_used and (min_run_number_used or max_run_number_used):
+            raise ParseError("run number and range run number cannot be used together.")
+
+        lumisection_id_used = "lumisection_id" in cleaned_data
+        ls_number_used = "ls_number" in cleaned_data
+        min_ls_number_used = "min_ls_number" in cleaned_data
+        max_ls_number_used = "max_ls_number" in cleaned_data
+
+        if ls_number_used and lumisection_id_used:
+            raise ParseError("ls number and lumisection id cannot be used together.")
+
+        if lumisection_id_used and (min_ls_number_used or max_ls_number_used):
+            raise ParseError("lumisection id and range ls number cannot be used together.")
+
+        if ls_number_used and (min_ls_number_used or max_ls_number_used):
+            raise ParseError("ls number and range ls number cannot be used together.")
+
+        title_used = "title" in cleaned_data
+        title_contains_used = "title_contains" in cleaned_data
+
+        if title_used and title_contains_used:
+            raise ParseError("title and title contains cannot be used together.")
+
+        return queryset
 
     class Meta:
         model = LumisectionHistogram1D
@@ -71,6 +118,37 @@ class LumisectionHistogram2DFilter(filters.FilterSet):
     )
     title_contains = filters.CharFilter(label="Title contains", field_name="title", lookup_expr="contains")
     min_entries = filters.NumberFilter(label="Minimum number of entries", field_name="entries", lookup_expr="gte")
+
+    def filter_queryset(self, queryset, *args, **kwargs):
+        queryset = super().filter_queryset(queryset, *args, **kwargs)
+        cleaned_data = {key: value for key, value in self.form.cleaned_data.items() if value is not None}
+
+        run_number_used = "run_number" in cleaned_data
+        min_run_number_used = "min_run_number" in cleaned_data
+        max_run_number_used = "max_run_number" in cleaned_data
+
+        if run_number_used and (min_run_number_used or max_run_number_used):
+            raise ParseError("run number and range run number cannot be used together.")
+
+        lumisection_id_used = "lumisection_id" in cleaned_data
+        ls_number_used = "ls_number" in cleaned_data
+        min_ls_number_used = "min_ls_number" in cleaned_data
+        max_ls_number_used = "max_ls_number" in cleaned_data
+
+        if ls_number_used and lumisection_id_used:
+            raise ParseError("ls number and lumisection id cannot be used together.")
+
+        if lumisection_id_used and (min_ls_number_used or max_ls_number_used):
+            raise ParseError("lumisection id and range ls number cannot be used together.")
+
+        if ls_number_used and (min_ls_number_used or max_ls_number_used):
+            raise ParseError("ls number and range ls number cannot be used together.")
+
+        title_used = "title" in cleaned_data
+        title_contains_used = "title_contains" in cleaned_data
+
+        if title_used and title_contains_used:
+            raise ParseError("title and title contains cannot be used together.")
 
     class Meta:
         model = LumisectionHistogram2D


### PR DESCRIPTION
Viewset `LumisectionViewSet`, `LumisectionHistogram1DViewSet` and `LumisectionHistogram2DViewSet` have filters that shouldn't be used simultaneously, so for each of those filter classes overwrite the `filter_queryset` to check if the filters were used together and raise a ParseError exception (from DRF) to return 400 Bad Request in the api call.

Also, minor modification in pre-commit configuration file to remove `fail_fast` key.