### PR TITLE
Hotfix filter_query of LumisectionHistogram2DFilter

### DIFF
--- a/backend/dials/dqmio_etl/filters.py
+++ b/backend/dials/dqmio_etl/filters.py
@@ -165,6 +165,8 @@ class LumisectionHistogram2DFilter(filters.FilterSet):
         if title_used and title_contains_used:
             raise ParseError("title and title contains cannot be used together.")
 
+        return queryset
+
     class Meta:
         model = LumisectionHistogram2D
         fields = [


### PR DESCRIPTION
fix: `filter_queryset` in `LumisectionHistogram2DFilter` not returning queryset