### PR TITLE
Feature: add data ingestion priority queue

### DIFF
--- a/backend/dials/settings.py
+++ b/backend/dials/settings.py
@@ -201,7 +201,7 @@ CELERY_BEAT_SCHEDULE = {
 CELERY_BROKER_TRANSPORT_OPTIONS = {"visibility_timeout": 60 * 60 * 24 * 2}  # seconds
 
 # Path used in dqmio_file_indexer app to discover DQMIO files
-DIR_PATH_DQMIO_STORAGE = config("DJANGO_DQMIO_STORAGE")
+DIR_PATH_DQMIO_STORAGE = json.loads(config("DJANGO_DQMIO_STORAGE", default="[]"))
 
 # List of MEs to ingest
 DQMIO_MES_TO_INGEST = get_monitoring_elements_names()

--- a/backend/dqmio_etl/serializers.py
+++ b/backend/dqmio_etl/serializers.py
@@ -35,6 +35,7 @@ class LumisectionHistogram2DSerializer(serializers.ModelSerializer):
 
 class LumisectionHistogramsIngestionInputSerializer(serializers.Serializer):
     id = serializers.IntegerField()
+    queue = serializers.CharField()
 
 
 class LumisectionHistogramsSubsystemCountSerializer(serializers.Serializer):

--- a/backend/dqmio_etl/tasks.py
+++ b/backend/dqmio_etl/tasks.py
@@ -1,7 +1,6 @@
 import logging
 
 from dials import celery_app
-from dqmio_file_indexer.models import FileIndex
 
 from .methods import HistIngestion
 
@@ -9,8 +8,8 @@ from .methods import HistIngestion
 logger = logging.getLogger(__name__)
 
 
-@celery_app.task(queue="dqmio_etl_queue")
-def ingest_function(file_index: FileIndex):
-    ing = HistIngestion(file_index)
+@celery_app.task
+def ingest_function(file_index_id: int):
+    ing = HistIngestion(file_index_id)
     result = ing.run()
     return result

--- a/backend/dqmio_file_indexer/tasks.py
+++ b/backend/dqmio_file_indexer/tasks.py
@@ -4,7 +4,7 @@ from utils.redis_lock import run_if_not_locked, with_lock
 from .methods import RawDataIndexer
 
 
-@celery_app.task(queue="dqmio_file_indexer_queue", name="dqmio_file_indexer.tasks.index_files_and_schedule_hists")
+@celery_app.task(queue="etl_file_indexer", name="dqmio_file_indexer.tasks.index_files_and_schedule_hists")
 @run_if_not_locked(lock_name="LOCK_index_files_and_schedule_hists")
 @with_lock(lock_name="LOCK_index_files_and_schedule_hists")
 def index_files_and_schedule_hists():
@@ -14,7 +14,7 @@ def index_files_and_schedule_hists():
     return result
 
 
-@celery_app.task(queue="celery_periodic", name="dqmio_file_indexer.tasks.handle_periodic", ignore_result=True)
+@celery_app.task(queue="periodic_scheduler", name="dqmio_file_indexer.tasks.handle_periodic", ignore_result=True)
 @run_if_not_locked(lock_name="LOCK_index_files_and_schedule_hists")
 def handle_periodic():
     index_files_and_schedule_hists.apply_async()

--- a/backend/scripts/start-dev.sh
+++ b/backend/scripts/start-dev.sh
@@ -6,15 +6,17 @@ if [ "$(basename $CURR_PATH)" != "backend" ]; then
     cd "backend" || exit 1
 fi
 
-poetry run celery -A dials worker -l INFO -c 1 -n worker1 -Q dqmio_file_indexer_queue &
+poetry run celery --app=dials beat --loglevel=INFO --schedule=celerybeat-schedule &
 P1=$!
-poetry run celery -A dials worker -l INFO -c 1 -n worker2 -Q dqmio_etl_queue &
+poetry run celery --app=dials worker --loglevel=INFO --concurrency=2 --autoscale=4,2 --hostname=periodic_worker --queues=periodic_scheduler &
 P2=$!
-poetry run celery -A dials worker -l INFO -n worker3 -Q celery_periodic &
+poetry run celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --hostname=indexer_worker --queues=etl_file_indexer &
 P3=$!
-poetry run celery -A dials beat -l INFO &
+poetry run celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=2,0 --hostname=etl_bulk_worker --queues=etl_bulk_ingestion &
 P4=$!
-poetry run python manage.py runserver 0.0.0.0:8000
+poetry run celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=2,0 --hostname=etl_priority_worker --queues=etl_priority_ingestion &
 P5=$!
+poetry run python manage.py runserver 0.0.0.0:8000
+P6=$!
 
-wait $P1 $P2 $P3 $P4 $P5
+wait $P1 $P2 $P3 $P4 $P5 $P6

--- a/backend/scripts/start-flower.sh
+++ b/backend/scripts/start-flower.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+CURR_PATH=$(pwd)
+
+if [ "$(basename $CURR_PATH)" != "backend" ]; then
+    cd "backend" || exit 1
+fi
+
+celery -A dials flower &
+P1=$!
+
+wait $P1

--- a/backend/scripts/start-flower.sh
+++ b/backend/scripts/start-flower.sh
@@ -6,7 +6,7 @@ if [ "$(basename $CURR_PATH)" != "backend" ]; then
     cd "backend" || exit 1
 fi
 
-celery -A dials flower &
+celery -A dials flower
 P1=$!
 
 wait $P1

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -17,8 +17,53 @@
 version: '3'
 
 services:
-  django_rest_api_prod:
-    container_name: django_rest_api_prod
+  celery_beat_prod:
+    container_name: celery_beat_prod
+    image: backend_prod
+    volumes:
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials beat --loglevel=INFO --schedule=celerybeat-schedule'
+    network_mode: "host"
+    env_file: ./backend/.env.dev-prod
+
+  celery_worker_periodic_prod:
+    container_name: celery_worker_periodic_prod
+    image: backend_prod
+    volumes:
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials worker --loglevel=INFO --concurrency=2 --autoscale=4,2 --hostname=periodic_worker --queues=periodic_scheduler'
+    network_mode: "host"
+    env_file: ./backend/.env.dev-prod
+
+  celery_worker_indexer_prod:
+    container_name: celery_worker_indexer_prod
+    image: backend_prod
+    volumes:
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --hostname=indexer_worker --queues=etl_file_indexer'
+    network_mode: "host"
+    env_file: ./backend/.env.dev-prod
+
+  celery_worker_bulk_prod:
+    container_name: celery_worker_bulk_prod
+    image: backend_prod
+    volumes:
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=2,0 --hostname=etl_bulk_worker --queues=etl_bulk_ingestion'
+    network_mode: "host"
+    env_file: ./backend/.env.dev-prod
+
+  celery_worker_priority_prod:
+    container_name: celery_worker_priority_prod
+    image: backend_prod
+    volumes:
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=2,0 --hostname=etl_priority_worker --queues=etl_priority_ingestion'
+    network_mode: "host"
+    env_file: ./backend/.env.dev-prod
+
+  django_restapi_prod:
+    container_name: django_restapi_prod
     image: backend_prod
     build:
       dockerfile: backend/Dockerfile
@@ -26,42 +71,6 @@ services:
     volumes:
       - /mnt/dqmio:/mnt/dqmio
     command: bash -c 'python3 -m gunicorn dials.asgi:application -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8000'
-    network_mode: "host"
-    env_file: ./backend/.env.dev-prod
-
-  django_celery_worker1_prod:
-    container_name: django_celery_worker1_prod
-    image: backend_prod
-    volumes:
-      - /mnt/dqmio:/mnt/dqmio
-    command: bash -c 'celery -A dials worker -l INFO -c 1 -n worker1 -Q dqmio_file_indexer_queue'
-    network_mode: "host"
-    env_file: ./backend/.env.dev-prod
-
-  django_celery_worker2_prod:
-    container_name: django_celery_worker2_prod
-    image: backend_prod
-    volumes:
-      - /mnt/dqmio:/mnt/dqmio
-    command: bash -c 'celery -A dials worker -l INFO -c 1 -n worker2 -Q dqmio_etl_queue'
-    network_mode: "host"
-    env_file: ./backend/.env.dev-prod
-
-  django_celery_worker3_prod:
-    container_name: django_celery_worker3_prod
-    image: backend_prod
-    volumes:
-      - /mnt/dqmio:/mnt/dqmio
-    command: bash -c 'celery -A dials worker -l INFO -n worker3 -Q celery_periodic'
-    network_mode: "host"
-    env_file: ./backend/.env.dev-prod
-
-  django_celery_beat_prod:
-    container_name: django_celery_beat_prod
-    image: backend_prod
-    volumes:
-      - /mnt/dqmio:/mnt/dqmio
-    command: bash -c 'celery -A dials beat -l INFO'
     network_mode: "host"
     env_file: ./backend/.env.dev-prod
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,8 +16,53 @@
 version: '3'
 
 services:
-  django_rest_api_dev:
-    container_name: django_rest_api_dev
+  celery_beat_dev:
+    container_name: celery_beat_dev
+    image: backend_dev
+    volumes:
+      - ./backend/:/home/app/rest_api
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials beat --loglevel=INFO --schedule=celerybeat-schedule'
+    network_mode: "host"
+
+  celery_worker_periodic_dev:
+    container_name: celery_worker_periodic_dev
+    image: backend_dev
+    volumes:
+      - ./backend/:/home/app/rest_api
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials worker --loglevel=INFO --concurrency=2 --autoscale=4,2 --hostname=periodic_worker --queues=periodic_scheduler'
+    network_mode: "host"
+
+  celery_worker_indexer_dev:
+    container_name: celery_worker_indexer_dev
+    image: backend_dev
+    volumes:
+      - ./backend/:/home/app/rest_api
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --hostname=indexer_worker --queues=etl_file_indexer'
+    network_mode: "host"
+
+  celery_worker_bulk_dev:
+    container_name: celery_worker_bulk_dev
+    image: backend_dev
+    volumes:
+      - ./backend/:/home/app/rest_api
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=2,0 --hostname=etl_bulk_worker --queues=etl_bulk_ingestion'
+    network_mode: "host"
+
+  celery_worker_priority_dev:
+    container_name: celery_worker_priority_dev
+    image: backend_dev
+    volumes:
+      - ./backend/:/home/app/rest_api
+      - /mnt/dqmio:/mnt/dqmio
+    command: bash -c 'celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=2,0 --hostname=etl_priority_worker --queues=etl_priority_ingestion'
+    network_mode: "host"
+
+  django_restapi_dev:
+    container_name: django_restapi_dev
     image: backend_dev
     build:
       dockerfile: backend/Dockerfile
@@ -29,42 +74,6 @@ services:
       - ./backend/:/home/app/rest_api
       - /mnt/dqmio:/mnt/dqmio
     command: bash -c 'python3 manage.py runserver 0.0.0.0:8000'
-    network_mode: "host"
-
-  django_celery_worker1_dev:
-    container_name: django_celery_worker1_dev
-    image: backend_dev
-    volumes:
-      - ./backend/:/home/app/rest_api
-      - /mnt/dqmio:/mnt/dqmio
-    command: bash -c 'celery -A dials worker -l INFO -c 1 -n worker1 -Q dqmio_file_indexer_queue'
-    network_mode: "host"
-
-  django_celery_worker2_dev:
-    container_name: django_celery_worker2_dev
-    image: backend_dev
-    volumes:
-      - ./backend/:/home/app/rest_api
-      - /mnt/dqmio:/mnt/dqmio
-    command: bash -c 'celery -A dials worker -l INFO -c 1 -n worker2 -Q dqmio_etl_queue'
-    network_mode: "host"
-
-  django_celery_worker3_dev:
-    container_name: django_celery_worker3_dev
-    image: backend_dev
-    volumes:
-      - ./backend/:/home/app/rest_api
-      - /mnt/dqmio:/mnt/dqmio
-    command: bash -c 'celery -A dials worker -l INFO -n worker3 -Q celery_periodic'
-    network_mode: "host"
-
-  django_celery_beat_dev:
-    container_name: django_celery_beat_dev
-    image: backend_dev
-    volumes:
-      - ./backend/:/home/app/rest_api
-      - /mnt/dqmio:/mnt/dqmio
-    command: bash -c 'celery -A dials beat -l INFO'
     network_mode: "host"
 
   frontend_dev:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -45,7 +45,7 @@ COPY package.json $APP_HOME
 COPY yarn.lock $APP_HOME
 COPY .eslintignore $APP_HOME
 COPY .eslintrc.js $APP_HOME
-COPY vite.config.js $APP_HOME
+COPY vite.config.mjs $APP_HOME
 COPY frontend $APP_HOME/frontend
 
 RUN chown -R $USERNAME:$USERNAME $HOME

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -13,7 +13,7 @@ RUN yarn install
 
 COPY .eslintignore $APP_HOME
 COPY .eslintrc.js $APP_HOME
-COPY vite.config.js /usr/src/app/
+COPY vite.config.mjs /usr/src/app/
 COPY frontend /usr/src/app/frontend
 
 RUN yarn build

--- a/oc/prod/deployment.yaml
+++ b/oc/prod/deployment.yaml
@@ -1,26 +1,26 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: backend-api
+  name: best-scheduler
   namespace: cms-dials-prod
   labels:
-    app: backend-api
-    app.kubernetes.io/component: backend-api
-    app.kubernetes.io/instance: backend-api
-    app.kubernetes.io/name: backend-api
-    app.kubernetes.io/part-of: dials
-    app.openshift.io/runtime: django
+    app: best-scheduler
+    app.kubernetes.io/component: best-scheduler
+    app.kubernetes.io/instance: best-scheduler
+    app.kubernetes.io/name: best-scheduler
+    app.kubernetes.io/part-of: celery-beats
+    app.openshift.io/runtime: redis
     app.openshift.io/runtime-namespace: cms-dials-prod
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: backend-api
+      app: best-scheduler
   template:
     metadata:
       labels:
-        app: backend-api
-        deployment: backend-api
+        app: best-scheduler
+        deployment: best-scheduler
       annotations:
         eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
     spec:
@@ -29,7 +29,737 @@ spec:
           persistentVolumeClaim:
             claimName: eos-storage
       containers:
-        - name: backend-api
+        - name: best-scheduler
+          resources:
+            requests:
+              memory: 256Mi
+            limits:
+              memory: 1024Mi
+          entrypoint: ''
+          command:
+            - bash
+            - '-c'
+            - >-
+              celery --app=dials beat --loglevel=INFO --schedule=/tmp/celerybeat-schedule
+          env:
+            - name: DJANGO_ENV
+              value: prod
+            - name: DJANGO_DEBUG
+              value: '0'
+            - name: DJANGO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_SECRET_KEY
+            - name: DJANGO_ALLOWED_HOSTS
+              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
+            - name: DJANGO_CSRF_TRUSTED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_CORS_ALLOWED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_NAME
+            - name: DJANGO_DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_USER
+            - name: DJANGO_DATABASE_ENGINE
+              value: django.db.backends.postgresql
+            - name: DJANGO_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PASSWORD
+            - name: DJANGO_DATABASE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PORT
+            - name: DJANGO_DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_HOST
+            - name: DJANGO_CELERY_BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_CELERY_BROKER_URL
+            - name: DJANGO_DQMIO_STORAGE
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DQMIO_STORAGE
+            - name: DJANGO_KEYCLOAK_SERVER_URL
+              value: 'https://auth.cern.ch/auth/'
+            - name: DJANGO_KEYCLOAK_REALM
+              value: cern
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_API_CLIENTS
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_API_CLIENTS
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: eos-storage
+              readOnly: true
+              mountPath: /eos
+          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: periodic-scheduler
+  namespace: cms-dials-prod
+  labels:
+    app: periodic-scheduler
+    app.kubernetes.io/component: periodic-scheduler
+    app.kubernetes.io/instance: periodic-scheduler
+    app.kubernetes.io/name: periodic-scheduler
+    app.kubernetes.io/part-of: celery-workers
+    app.openshift.io/runtime: redis
+    app.openshift.io/runtime-namespace: cms-dials-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: periodic-scheduler
+  template:
+    metadata:
+      labels:
+        app: periodic-scheduler
+        deployment: periodic-scheduler
+      annotations:
+        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
+    spec:
+      volumes:
+        - name: eos-storage
+          persistentVolumeClaim:
+            claimName: eos-storage
+      containers:
+        - name: periodic-scheduler
+          resources:
+            requests:
+              memory: 256Mi
+            limits:
+              memory: 1024Mi
+          entrypoint: ''
+          command:
+            - bash
+            - '-c'
+            - >-
+              celery --app=dials worker --loglevel=INFO --concurrency=2 --autoscale=4,2 --hostname=periodic_worker --queues=periodic_scheduler
+          env:
+            - name: DJANGO_ENV
+              value: prod
+            - name: DJANGO_DEBUG
+              value: '0'
+            - name: DJANGO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_SECRET_KEY
+            - name: DJANGO_ALLOWED_HOSTS
+              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
+            - name: DJANGO_CSRF_TRUSTED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_CORS_ALLOWED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_NAME
+            - name: DJANGO_DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_USER
+            - name: DJANGO_DATABASE_ENGINE
+              value: django.db.backends.postgresql
+            - name: DJANGO_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PASSWORD
+            - name: DJANGO_DATABASE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PORT
+            - name: DJANGO_DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_HOST
+            - name: DJANGO_CELERY_BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_CELERY_BROKER_URL
+            - name: DJANGO_DQMIO_STORAGE
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DQMIO_STORAGE
+            - name: DJANGO_KEYCLOAK_SERVER_URL
+              value: 'https://auth.cern.ch/auth/'
+            - name: DJANGO_KEYCLOAK_REALM
+              value: cern
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_API_CLIENTS
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_API_CLIENTS
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: eos-storage
+              readOnly: true
+              mountPath: /eos
+          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: file-indexer
+  namespace: cms-dials-prod
+  labels:
+    app: file-indexer
+    app.kubernetes.io/component: file-indexer
+    app.kubernetes.io/instance: file-indexer
+    app.kubernetes.io/name: file-indexer
+    app.kubernetes.io/part-of: celery-workers
+    app.openshift.io/runtime: redis
+    app.openshift.io/runtime-namespace: cms-dials-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: file-indexer
+  template:
+    metadata:
+      labels:
+        app: file-indexer
+        deployment: file-indexer
+      annotations:
+        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
+    spec:
+      volumes:
+        - name: eos-storage
+          persistentVolumeClaim:
+            claimName: eos-storage
+      containers:
+        - name: file-indexer
+          resources:
+            requests:
+              memory: 256Mi
+            limits:
+              memory: 1024Mi
+          entrypoint: ''
+          command:
+            - bash
+            - '-c'
+            - >-
+              celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --hostname=indexer_worker --queues=etl_file_indexer
+          env:
+            - name: DJANGO_ENV
+              value: prod
+            - name: DJANGO_DEBUG
+              value: '0'
+            - name: DJANGO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_SECRET_KEY
+            - name: DJANGO_ALLOWED_HOSTS
+              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
+            - name: DJANGO_CSRF_TRUSTED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_CORS_ALLOWED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_NAME
+            - name: DJANGO_DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_USER
+            - name: DJANGO_DATABASE_ENGINE
+              value: django.db.backends.postgresql
+            - name: DJANGO_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PASSWORD
+            - name: DJANGO_DATABASE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PORT
+            - name: DJANGO_DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_HOST
+            - name: DJANGO_CELERY_BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_CELERY_BROKER_URL
+            - name: DJANGO_DQMIO_STORAGE
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DQMIO_STORAGE
+            - name: DJANGO_KEYCLOAK_SERVER_URL
+              value: 'https://auth.cern.ch/auth/'
+            - name: DJANGO_KEYCLOAK_REALM
+              value: cern
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_API_CLIENTS
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_API_CLIENTS
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: eos-storage
+              readOnly: true
+              mountPath: /eos
+          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: bulk-ingestion
+  namespace: cms-dials-prod
+  labels:
+    app: bulk-ingestion
+    app.kubernetes.io/component: bulk-ingestion
+    app.kubernetes.io/instance: bulk-ingestion
+    app.kubernetes.io/name: bulk-ingestion
+    app.kubernetes.io/part-of: celery-workers
+    app.openshift.io/runtime: redis
+    app.openshift.io/runtime-namespace: cms-dials-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bulk-ingestion
+  template:
+    metadata:
+      labels:
+        app: bulk-ingestion
+        deployment: bulk-ingestion
+      annotations:
+        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
+    spec:
+      volumes:
+        - name: eos-storage
+          persistentVolumeClaim:
+            claimName: eos-storage
+      containers:
+        - name: bulk-ingestion
+          resources:
+            requests:
+              memory: 1024Mi
+            limits:
+              memory: 4096Mi
+          entrypoint: ''
+          command:
+            - bash
+            - '-c'
+            - >-
+              celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=2,0 --hostname=etl_bulk_worker --queues=etl_bulk_ingestion
+          env:
+            - name: DJANGO_ENV
+              value: prod
+            - name: DJANGO_DEBUG
+              value: '0'
+            - name: DJANGO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_SECRET_KEY
+            - name: DJANGO_ALLOWED_HOSTS
+              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
+            - name: DJANGO_CSRF_TRUSTED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_CORS_ALLOWED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_NAME
+            - name: DJANGO_DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_USER
+            - name: DJANGO_DATABASE_ENGINE
+              value: django.db.backends.postgresql
+            - name: DJANGO_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PASSWORD
+            - name: DJANGO_DATABASE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PORT
+            - name: DJANGO_DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_HOST
+            - name: DJANGO_CELERY_BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_CELERY_BROKER_URL
+            - name: DJANGO_DQMIO_STORAGE
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DQMIO_STORAGE
+            - name: DJANGO_KEYCLOAK_SERVER_URL
+              value: 'https://auth.cern.ch/auth/'
+            - name: DJANGO_KEYCLOAK_REALM
+              value: cern
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_API_CLIENTS
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_API_CLIENTS
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: eos-storage
+              readOnly: true
+              mountPath: /eos
+          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: priority-ingestion
+  namespace: cms-dials-prod
+  labels:
+    app: priority-ingestion
+    app.kubernetes.io/component: priority-ingestion
+    app.kubernetes.io/instance: priority-ingestion
+    app.kubernetes.io/name: priority-ingestion
+    app.kubernetes.io/part-of: celery-workers
+    app.openshift.io/runtime: redis
+    app.openshift.io/runtime-namespace: cms-dials-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: priority-ingestion
+  template:
+    metadata:
+      labels:
+        app: priority-ingestion
+        deployment: priority-ingestion
+      annotations:
+        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
+    spec:
+      volumes:
+        - name: eos-storage
+          persistentVolumeClaim:
+            claimName: eos-storage
+      containers:
+        - name: priority-ingestion
+          resources:
+            requests:
+              memory: 1024Mi
+            limits:
+              memory: 4096Mi
+          entrypoint: ''
+          command:
+            - bash
+            - '-c'
+            - >-
+              celery --app=dials worker --loglevel=INFO --concurrency=1 --autoscale=2,0 --hostname=etl_bulk_worker --queues=etl_priority_ingestion
+          env:
+            - name: DJANGO_ENV
+              value: prod
+            - name: DJANGO_DEBUG
+              value: '0'
+            - name: DJANGO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_SECRET_KEY
+            - name: DJANGO_ALLOWED_HOSTS
+              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
+            - name: DJANGO_CSRF_TRUSTED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_CORS_ALLOWED_ORIGINS
+              value: >-
+                https://cmsdials-api.web.cern.ch
+                https://cmsdials.web.cern.ch
+            - name: DJANGO_DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_NAME
+            - name: DJANGO_DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_USER
+            - name: DJANGO_DATABASE_ENGINE
+              value: django.db.backends.postgresql
+            - name: DJANGO_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PASSWORD
+            - name: DJANGO_DATABASE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_PORT
+            - name: DJANGO_DATABASE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DATABASE_HOST
+            - name: DJANGO_CELERY_BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_CELERY_BROKER_URL
+            - name: DJANGO_DQMIO_STORAGE
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_DQMIO_STORAGE
+            - name: DJANGO_KEYCLOAK_SERVER_URL
+              value: 'https://auth.cern.ch/auth/'
+            - name: DJANGO_KEYCLOAK_REALM
+              value: cern
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
+            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
+            - name: DJANGO_KEYCLOAK_API_CLIENTS
+              valueFrom:
+                secretKeyRef:
+                  name: dials-secrets
+                  key: DJANGO_KEYCLOAK_API_CLIENTS
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: eos-storage
+              readOnly: true
+              mountPath: /eos
+          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: backend-restapi
+  namespace: cms-dials-prod
+  labels:
+    app: backend-restapi
+    app.kubernetes.io/component: backend-restapi
+    app.kubernetes.io/instance: backend-restapi
+    app.kubernetes.io/name: backend-restapi
+    app.kubernetes.io/part-of: dials
+    app.openshift.io/runtime: django
+    app.openshift.io/runtime-namespace: cms-dials-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend-restapi
+  template:
+    metadata:
+      labels:
+        app: backend-restapi
+        deployment: backend-restapi
+      annotations:
+        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
+    spec:
+      volumes:
+        - name: eos-storage
+          persistentVolumeClaim:
+            claimName: eos-storage
+      containers:
+        - name: backend-restapi
           resources:
             requests:
               memory: 256Mi
@@ -42,594 +772,6 @@ spec:
               python3 -m gunicorn
               dials.asgi:application -k uvicorn.workers.UvicornWorker -b
               0.0.0.0:8000
-          env:
-            - name: DJANGO_ENV
-              value: prod
-            - name: DJANGO_DEBUG
-              value: '0'
-            - name: DJANGO_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_SECRET_KEY
-            - name: DJANGO_ALLOWED_HOSTS
-              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
-            - name: DJANGO_CSRF_TRUSTED_ORIGINS
-              value: >-
-                https://cmsdials-api.web.cern.ch
-                https://cmsdials.web.cern.ch
-            - name: DJANGO_CORS_ALLOWED_ORIGINS
-              value: >-
-                https://cmsdials-api.web.cern.ch
-                https://cmsdials.web.cern.ch
-            - name: DJANGO_DATABASE_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_NAME
-            - name: DJANGO_DATABASE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_USER
-            - name: DJANGO_DATABASE_ENGINE
-              value: django.db.backends.postgresql
-            - name: DJANGO_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_PASSWORD
-            - name: DJANGO_DATABASE_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_PORT
-            - name: DJANGO_DATABASE_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_HOST
-            - name: DJANGO_CELERY_BROKER_URL
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_CELERY_BROKER_URL
-            - name: DJANGO_DQMIO_STORAGE
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DQMIO_STORAGE
-            - name: DJANGO_KEYCLOAK_SERVER_URL
-              value: 'https://auth.cern.ch/auth/'
-            - name: DJANGO_KEYCLOAK_REALM
-              value: cern
-            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
-            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
-            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
-            - name: DJANGO_KEYCLOAK_API_CLIENTS
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_API_CLIENTS
-          ports:
-            - containerPort: 8000
-              protocol: TCP
-          imagePullPolicy: Always
-          volumeMounts:
-            - name: eos-storage
-              readOnly: true
-              mountPath: /eos
-          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 30
-      dnsPolicy: ClusterFirst
-      schedulerName: default-scheduler
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 25%
-      maxSurge: 25%
-  revisionHistoryLimit: 10
-  progressDeadlineSeconds: 600
-
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: backend-worker-1
-  namespace: cms-dials-prod
-  labels:
-    app: backend-worker-1
-    app.kubernetes.io/component: backend-worker-1
-    app.kubernetes.io/instance: backend-worker-1
-    app.kubernetes.io/name: backend-worker-1
-    app.kubernetes.io/part-of: dials
-    app.openshift.io/runtime: redis
-    app.openshift.io/runtime-namespace: cms-dials-prod
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: backend-worker-1
-  template:
-    metadata:
-      labels:
-        app: backend-worker-1
-        deployment: backend-worker-1
-      annotations:
-        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
-    spec:
-      volumes:
-        - name: eos-storage
-          persistentVolumeClaim:
-            claimName: eos-storage
-      containers:
-        - name: backend-worker-1
-          resources:
-            requests:
-              memory: 256Mi
-            limits:
-              memory: 1024Mi
-          entrypoint: ''
-          command:
-            - bash
-            - '-c'
-            - >-
-              celery -A dials worker -l INFO -c 1 -n
-              worker1 -Q dqmio_file_indexer_queue
-          env:
-            - name: DJANGO_ENV
-              value: prod
-            - name: DJANGO_DEBUG
-              value: '0'
-            - name: DJANGO_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_SECRET_KEY
-            - name: DJANGO_ALLOWED_HOSTS
-              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
-            - name: DJANGO_CSRF_TRUSTED_ORIGINS
-              value: >-
-                https://cmsdials-api.web.cern.ch
-                https://cmsdials.web.cern.ch
-            - name: DJANGO_CORS_ALLOWED_ORIGINS
-              value: >-
-                https://cmsdials-api.web.cern.ch
-                https://cmsdials.web.cern.ch
-            - name: DJANGO_DATABASE_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_NAME
-            - name: DJANGO_DATABASE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_USER
-            - name: DJANGO_DATABASE_ENGINE
-              value: django.db.backends.postgresql
-            - name: DJANGO_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_PASSWORD
-            - name: DJANGO_DATABASE_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_PORT
-            - name: DJANGO_DATABASE_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_HOST
-            - name: DJANGO_CELERY_BROKER_URL
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_CELERY_BROKER_URL
-            - name: DJANGO_DQMIO_STORAGE
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DQMIO_STORAGE
-            - name: DJANGO_KEYCLOAK_SERVER_URL
-              value: 'https://auth.cern.ch/auth/'
-            - name: DJANGO_KEYCLOAK_REALM
-              value: cern
-            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
-            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
-            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
-            - name: DJANGO_KEYCLOAK_API_CLIENTS
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_API_CLIENTS
-          ports:
-            - containerPort: 8000
-              protocol: TCP
-          imagePullPolicy: Always
-          volumeMounts:
-            - name: eos-storage
-              readOnly: true
-              mountPath: /eos
-          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 30
-      dnsPolicy: ClusterFirst
-      schedulerName: default-scheduler
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 25%
-      maxSurge: 25%
-  revisionHistoryLimit: 10
-  progressDeadlineSeconds: 600
-
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: backend-worker-2
-  namespace: cms-dials-prod
-  labels:
-    app: backend-worker-2
-    app.kubernetes.io/component: backend-worker-2
-    app.kubernetes.io/instance: backend-worker-2
-    app.kubernetes.io/name: backend-worker-2
-    app.kubernetes.io/part-of: dials
-    app.openshift.io/runtime: redis
-    app.openshift.io/runtime-namespace: cms-dials-prod
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: backend-worker-2
-  template:
-    metadata:
-      labels:
-        app: backend-worker-2
-        deployment: backend-worker-2
-      annotations:
-        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
-    spec:
-      volumes:
-        - name: eos-storage
-          persistentVolumeClaim:
-            claimName: eos-storage
-      containers:
-        - name: backend-worker-2
-          resources:
-            requests:
-              memory: 1024Mi
-            limits:
-              memory: 4096Mi
-          entrypoint: ''
-          command:
-            - bash
-            - '-c'
-            - >-
-              celery -A dials worker -l INFO -c 1 -n
-              worker2 -Q dqmio_etl_queue
-          env:
-            - name: DJANGO_ENV
-              value: prod
-            - name: DJANGO_DEBUG
-              value: '0'
-            - name: DJANGO_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_SECRET_KEY
-            - name: DJANGO_ALLOWED_HOSTS
-              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
-            - name: DJANGO_CSRF_TRUSTED_ORIGINS
-              value: >-
-                https://cmsdials-api.web.cern.ch
-                https://cmsdials.web.cern.ch
-            - name: DJANGO_CORS_ALLOWED_ORIGINS
-              value: >-
-                https://cmsdials-api.web.cern.ch
-                https://cmsdials.web.cern.ch
-            - name: DJANGO_DATABASE_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_NAME
-            - name: DJANGO_DATABASE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_USER
-            - name: DJANGO_DATABASE_ENGINE
-              value: django.db.backends.postgresql
-            - name: DJANGO_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_PASSWORD
-            - name: DJANGO_DATABASE_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_PORT
-            - name: DJANGO_DATABASE_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_HOST
-            - name: DJANGO_CELERY_BROKER_URL
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_CELERY_BROKER_URL
-            - name: DJANGO_DQMIO_STORAGE
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DQMIO_STORAGE
-            - name: DJANGO_KEYCLOAK_SERVER_URL
-              value: 'https://auth.cern.ch/auth/'
-            - name: DJANGO_KEYCLOAK_REALM
-              value: cern
-            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
-            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
-            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
-            - name: DJANGO_KEYCLOAK_API_CLIENTS
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_API_CLIENTS
-          ports:
-            - containerPort: 8000
-              protocol: TCP
-          imagePullPolicy: Always
-          volumeMounts:
-            - name: eos-storage
-              readOnly: true
-              mountPath: /eos
-          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 30
-      dnsPolicy: ClusterFirst
-      schedulerName: default-scheduler
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 25%
-      maxSurge: 25%
-  revisionHistoryLimit: 10
-  progressDeadlineSeconds: 600
-
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: backend-worker-3
-  namespace: cms-dials-prod
-  labels:
-    app: backend-worker-3
-    app.kubernetes.io/component: backend-worker-3
-    app.kubernetes.io/instance: backend-worker-3
-    app.kubernetes.io/name: backend-worker-3
-    app.kubernetes.io/part-of: dials
-    app.openshift.io/runtime: redis
-    app.openshift.io/runtime-namespace: cms-dials-prod
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: backend-worker-3
-  template:
-    metadata:
-      labels:
-        app: backend-worker-3
-        deployment: backend-worker-3
-      annotations:
-        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
-    spec:
-      volumes:
-        - name: eos-storage
-          persistentVolumeClaim:
-            claimName: eos-storage
-      containers:
-        - name: backend-worker-3
-          resources:
-            requests:
-              memory: 256Mi
-            limits:
-              memory: 1024Mi
-          entrypoint: ''
-          command:
-            - bash
-            - '-c'
-            - >-
-              celery -A dials worker -l INFO -c 4 -n
-              worker3 -Q celery_periodic
-          env:
-            - name: DJANGO_ENV
-              value: prod
-            - name: DJANGO_DEBUG
-              value: '0'
-            - name: DJANGO_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_SECRET_KEY
-            - name: DJANGO_ALLOWED_HOSTS
-              value: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
-            - name: DJANGO_CSRF_TRUSTED_ORIGINS
-              value: >-
-                https://cmsdials-api.web.cern.ch
-                https://cmsdials.web.cern.ch
-            - name: DJANGO_CORS_ALLOWED_ORIGINS
-              value: >-
-                https://cmsdials-api.web.cern.ch
-                https://cmsdials.web.cern.ch
-            - name: DJANGO_DATABASE_NAME
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_NAME
-            - name: DJANGO_DATABASE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_USER
-            - name: DJANGO_DATABASE_ENGINE
-              value: django.db.backends.postgresql
-            - name: DJANGO_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_PASSWORD
-            - name: DJANGO_DATABASE_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_PORT
-            - name: DJANGO_DATABASE_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DATABASE_HOST
-            - name: DJANGO_CELERY_BROKER_URL
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_CELERY_BROKER_URL
-            - name: DJANGO_DQMIO_STORAGE
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_DQMIO_STORAGE
-            - name: DJANGO_KEYCLOAK_SERVER_URL
-              value: 'https://auth.cern.ch/auth/'
-            - name: DJANGO_KEYCLOAK_REALM
-              value: cern
-            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_CLIENT_ID
-            - name: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_KEY
-            - name: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID
-            - name: DJANGO_KEYCLOAK_API_CLIENTS
-              valueFrom:
-                secretKeyRef:
-                  name: dials-secrets
-                  key: DJANGO_KEYCLOAK_API_CLIENTS
-          ports:
-            - containerPort: 8000
-              protocol: TCP
-          imagePullPolicy: Always
-          volumeMounts:
-            - name: eos-storage
-              readOnly: true
-              mountPath: /eos
-          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/backend:latest
-      restartPolicy: Always
-      terminationGracePeriodSeconds: 30
-      dnsPolicy: ClusterFirst
-      schedulerName: default-scheduler
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 25%
-      maxSurge: 25%
-  revisionHistoryLimit: 10
-  progressDeadlineSeconds: 600
-
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: backend-beat
-  namespace: cms-dials-prod
-  labels:
-    app: backend-beat
-    app.kubernetes.io/component: backend-beat
-    app.kubernetes.io/instance: backend-beat
-    app.kubernetes.io/name: backend-beat
-    app.kubernetes.io/part-of: dials
-    app.openshift.io/runtime: redis
-    app.openshift.io/runtime-namespace: cms-dials-prod
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: backend-beat
-  template:
-    metadata:
-      labels:
-        app: backend-beat
-        deployment: backend-beat
-      annotations:
-        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
-    spec:
-      volumes:
-        - name: eos-storage
-          persistentVolumeClaim:
-            claimName: eos-storage
-      containers:
-        - name: backend-beat
-          resources:
-            requests:
-              memory: 256Mi
-            limits:
-              memory: 1024Mi
-          entrypoint: ''
-          command:
-            - bash
-            - '-c'
-            - >-
-              celery -A dials beat -l INFO -s
-              /tmp/celerybeat-schedule
           env:
             - name: DJANGO_ENV
               value: prod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ ruff = "^0.3.2"
 
 [tool.poe.tasks]
 start-dev = "./backend/scripts/start-dev.sh"
+start-flower = "./backend/scripts/start-flower.sh"
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
* add priority queue ingestion and rename all current queues and worker names

The `DJANGO_DQMIO_STORAGE` environment variable is refactored to be a list of objects containing the storage path and queue name which the files should be submitted for further processed (bulk/priority ingestion queues).
    
Update `start-dev.sh` script, docker-compose files and oc deployment files with new worker for priority ingestion queue and rename all containers, workers and queues to user-friendly names. Also add autoscaling tag to celery worker for better utilize computational resources depending on queue state.

Minor fixes and chores:
* add start-flow tasks to pyproject toml
* frontend's Dockerfiles including vite.config.js instead of vite.config.mjs