### PR TITLE
Fix resources names and remove empty entrypoint

### DIFF
--- a/oc/prod/deployment.yaml
+++ b/oc/prod/deployment.yaml
@@ -1,13 +1,13 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: best-scheduler
+  name: beat-scheduler
   namespace: cms-dials-prod
   labels:
-    app: best-scheduler
-    app.kubernetes.io/component: best-scheduler
-    app.kubernetes.io/instance: best-scheduler
-    app.kubernetes.io/name: best-scheduler
+    app: beat-scheduler
+    app.kubernetes.io/component: beat-scheduler
+    app.kubernetes.io/instance: beat-scheduler
+    app.kubernetes.io/name: beat-scheduler
     app.kubernetes.io/part-of: celery-beats
     app.openshift.io/runtime: redis
     app.openshift.io/runtime-namespace: cms-dials-prod
@@ -15,12 +15,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: best-scheduler
+      app: beat-scheduler
   template:
     metadata:
       labels:
-        app: best-scheduler
-        deployment: best-scheduler
+        app: beat-scheduler
+        deployment: beat-scheduler
       annotations:
         eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
     spec:
@@ -29,13 +29,12 @@ spec:
           persistentVolumeClaim:
             claimName: eos-storage
       containers:
-        - name: best-scheduler
+        - name: beat-scheduler
           resources:
             requests:
               memory: 256Mi
             limits:
               memory: 1024Mi
-          entrypoint: ''
           command:
             - bash
             - '-c'
@@ -181,7 +180,6 @@ spec:
               memory: 256Mi
             limits:
               memory: 1024Mi
-          entrypoint: ''
           command:
             - bash
             - '-c'
@@ -327,7 +325,6 @@ spec:
               memory: 256Mi
             limits:
               memory: 1024Mi
-          entrypoint: ''
           command:
             - bash
             - '-c'
@@ -473,7 +470,6 @@ spec:
               memory: 1024Mi
             limits:
               memory: 4096Mi
-          entrypoint: ''
           command:
             - bash
             - '-c'
@@ -619,7 +615,6 @@ spec:
               memory: 1024Mi
             limits:
               memory: 4096Mi
-          entrypoint: ''
           command:
             - bash
             - '-c'


### PR DESCRIPTION
* Rename `best-scheduler` to `beat-scheduler`
* Do not set entrypoint as empty string since it is not needed anymore