### PR TITLE
Hotfix wrong xrdcp arguments during downloading step

### DIFF
--- a/etl/python/common/lxplus_client.py
+++ b/etl/python/common/lxplus_client.py
@@ -21,15 +21,15 @@ class MinimalLXPlusClient:
         stdout = stdout.read().decode("utf-8").strip()
         return True if "Your proxy is valid" in stdout else False
 
-    def xrdcp(self, output_dir: str, fpath: str, redirector: str = "root://cms-xrd-global.cern.ch") -> str:
+    def xrdcp(self, output_dir: str, logical_file_name: str, redirector: str = "root://cms-xrd-global.cern.ch") -> str:
         """
         If multiple processes are trying to download the same file using xrdcp in the same destination,
         we found ourselves in a race condition, because xrdcp will fail with "Run: [ERROR] Local error: file exists:  (destination)"
         for every process that lost the race.
         """
-        fname = fpath.replace("/", "_")[1:]
+        fname = logical_file_name.replace("/", "_")[1:]
         out_fpath = f"{output_dir}/{fname}"
-        grid_fpath = f"{redirector}/{fpath}"
+        grid_fpath = f"{redirector}/{logical_file_name}"
         command = f"/usr/bin/timeout {self.timeout} /usr/bin/xrdcp {grid_fpath} {out_fpath}"
         _, stdout, stderr = self.client.exec_command(command)
         return_code = stdout.channel.recv_exit_status()

--- a/etl/python/pipelines/file_downloader/extract.py
+++ b/etl/python/pipelines/file_downloader/extract.py
@@ -30,4 +30,4 @@ def extract(logical_file_name: str) -> None:
         if client.is_file(remote_file_path):
             return
         client.init_proxy()
-        client.xrdcp(logical_file_name, remote_file_path)
+        client.xrdcp(remote_landing_dir, logical_file_name)


### PR DESCRIPTION
Downloading step were passing wrong arguments to xrdcp leading to failure while downloading files on disk, the final xrdcp command was.