### PR TITLE
Fix ETL post download not setting err_trace as None

### DIFF
--- a/etl/python/pipelines/file_downloader/post_download.py
+++ b/etl/python/pipelines/file_downloader/post_download.py
@@ -10,5 +10,6 @@ def post_download(engine: Engine, file_id: int) -> str:
     with session() as sess:
         row = sess.query(FactFileIndex).filter_by(file_id=file_id).first()
         row.status = StatusCollection.DOWNLOAD_FINISHED
+        row.err_trace = None
         sess.commit()
         return row.logical_file_name


### PR DESCRIPTION
When ETL's downloader phase finishes and set entry status as DOWNLOAD_FINISHED it sould also set the err_trace as None, this is useful in case a re-download is successful.