### PR TITLE
Fix ETL post download not setting err_trace as None

### DIFF
--- a/oc/prod/deployments/etl/common/flower.yaml
+++ b/oc/prod/deployments/etl/common/flower.yaml
@@ -37,7 +37,7 @@ spec:
             - bash
             - '-c'
             - >-
-              celery --app=python flower
+              celery --app=python flower --purge_offline_workers=120
           envFrom:
             - configMapRef:
                 name: dials-etl-configmap


### PR DESCRIPTION
When ETL's downloader phase finishes and set entry status as DOWNLOAD_FINISHED it sould also set the err_trace as None, this is useful in case a re-download is successful.