### PR TITLE
fix: make plotly charts truly resizable using builtin `useResizeHandler`

### DIFF
--- a/frontend/src/components/responsivePlot.jsx
+++ b/frontend/src/components/responsivePlot.jsx
@@ -1,39 +1,22 @@
 import React from 'react'
 
-import { useResizeDetector } from 'react-resize-detector'
 import Plot from 'react-plotly.js'
 import Spinner from 'react-bootstrap/Spinner'
 
 const ResponsivePlot = (props) => {
-  const {
-    width: resizedWidth,
-    height: resizedHeight,
-    ref,
-  } = useResizeDetector()
-  const { data, layout, config, boxWidth, boxHeight, isLoading } = props
-  const divStyle =
-    boxHeight && boxWidth
-      ? { height: boxHeight, width: boxWidth }
-      : { display: 'flex', height: '100%' }
-
+  const { data, layout, config, style, isLoading } = props
   return (
     <>
       {isLoading ? (
         <Spinner animation='border' role='status' />
       ) : (
-        <div ref={ref} style={divStyle}>
-          <Plot
-            data={data}
-            layout={{
-              ...layout,
-              ...{
-                width: resizedWidth,
-                height: resizedHeight,
-              },
-            }}
-            config={config}
-          />
-        </div>
+        <Plot
+          data={data}
+          layout={layout}
+          config={config}
+          useResizeHandler={true}
+          style={style}
+        />
       )}
     </>
   )

--- a/frontend/src/views/dataExplorer/histogram.jsx
+++ b/frontend/src/views/dataExplorer/histogram.jsx
@@ -173,8 +173,7 @@ const Histogram = (props) => {
                   <ResponsivePlot
                     data={plotData}
                     layout={plotLayout}
-                    boxWidth='100%'
-                    boxHeight='70vh'
+                    style={{ width: '100%', height: '70vh' }}
                   />
                 </>
               )}

--- a/frontend/src/views/dataExplorer/histograms1d.jsx
+++ b/frontend/src/views/dataExplorer/histograms1d.jsx
@@ -135,8 +135,7 @@ const Histograms1D = () => {
                 data={data}
                 layout={layout}
                 config={{ staticPlot: true }}
-                boxWidth={'200pt'}
-                boxHeight={'100pt'}
+                style={{ width: '100%', height: '100pt' }}
               />
             ),
           }

--- a/frontend/src/views/dataExplorer/histograms2d.jsx
+++ b/frontend/src/views/dataExplorer/histograms2d.jsx
@@ -135,8 +135,7 @@ const Histograms2D = () => {
                 data={data}
                 layout={layout}
                 config={{ staticPlot: true }}
-                boxWidth={'200pt'}
-                boxHeight={'100pt'}
+                style={{ width: '100%', height: '100pt' }}
               />
             ),
           }

--- a/frontend/src/views/dataIngestion/stats.jsx
+++ b/frontend/src/views/dataIngestion/stats.jsx
@@ -207,6 +207,7 @@ const IngestionStatistics = () => {
                 layout={layoutH1DPlot}
                 config={{ staticPlot: true }}
                 isLoading={isLoadingH1D}
+                style={{ width: '100%', height: '100%' }}
               />
             </Card.Body>
           </Card>
@@ -220,6 +221,7 @@ const IngestionStatistics = () => {
                 layout={layoutH2DPlot}
                 config={{ staticPlot: true }}
                 isLoading={isLoadingH2D}
+                style={{ width: '100%', height: '100%' }}
               />
             </Card.Body>
           </Card>
@@ -235,6 +237,7 @@ const IngestionStatistics = () => {
                 data={dataFilesPlot}
                 config={{ staticPlot: true }}
                 isLoading={isLoadingFiles}
+                style={{ width: '100%', height: '100%' }}
               />
             </Card.Body>
           </Card>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "react-dom": "^18.2.0",
     "react-oidc-context": "^3.0.0",
     "react-plotly.js": "^2.6.0",
-    "react-resize-detector": "^10.0.1",
     "react-router-dom": "^6.21.3",
     "react-toastify": "^10.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,7 +3265,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15, lodash@^4.17.21:
+lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3907,13 +3907,6 @@ react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
-
-react-resize-detector@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-10.0.1.tgz#ae9a8c5b6b93c4c11e03b3eb87e57fd7b62f1020"
-  integrity sha512-CR2EdP83ycGlWkhhrd6+hhZVhPJO4xnzClFCTBXlODVTHOgiDJQu77sBt67J7P3gfU4ec/kOuf2c5EcyTUNLXQ==
-  dependencies:
-    lodash "^4.17.21"
 
 react-router-dom@^6.21.3:
   version "6.22.3"


### PR DESCRIPTION
Fix issue #14.

- Make plotly charts truly resizable using builtin `useResizeHandler` (https://community.plotly.com/t/react-plotly-responsive-chart-not-working/47547);
- Remove `react-resize-detector` dependency.