### PR TITLE
refactor: replace `python-jose` with `jwcrypto` and update `python-keycloak`

### DIFF
--- a/backend/utils/rest_framework_cern_sso/authentication.py
+++ b/backend/utils/rest_framework_cern_sso/authentication.py
@@ -1,8 +1,8 @@
 from importlib import util as importlib_util
 
 from django.conf import settings
-from jwcrypto.jwt import JWTExpired, JWTNotYetValid
 from jwcrypto.jws import InvalidJWSSignature
+from jwcrypto.jwt import JWTExpired, JWTNotYetValid
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.request import Request
 
@@ -124,12 +124,14 @@ class CERNKeycloakBearerAuthentication(BaseAuthentication):
         try:
             token.validate(valid_aud, valid_azp)
         except InvalidJWSSignature as err:
-            raise AuthenticationFailed("Found and invalid jws signature while decoding the access token.", "access_token_invalid_jws_signature") from err
+            raise AuthenticationFailed(
+                "Found and invalid jws signature while decoding the access token.", "access_token_invalid_jws_signature"
+            ) from err
         except JWTExpired as err:
             raise AuthenticationFailed("Access token has expired.", "access_token_expired") from err
         except JWTNotYetValid as err:
             raise AuthenticationFailed("Access token not yet valid.", "access_token_not_yet_valid") from err
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001
             raise AuthenticationFailed("Unexpected error validating token.", "access_token_unexpected_error") from err
 
         return CERNKeycloakUser(token), token

--- a/backend/utils/rest_framework_cern_sso/authentication.py
+++ b/backend/utils/rest_framework_cern_sso/authentication.py
@@ -1,7 +1,8 @@
 from importlib import util as importlib_util
 
 from django.conf import settings
-from jose.exceptions import ExpiredSignatureError
+from jwcrypto.jwt import JWTExpired, JWTNotYetValid
+from jwcrypto.jws import InvalidJWSSignature
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.request import Request
 
@@ -122,8 +123,14 @@ class CERNKeycloakBearerAuthentication(BaseAuthentication):
 
         try:
             token.validate(valid_aud, valid_azp)
-        except ExpiredSignatureError as err:
+        except InvalidJWSSignature as err:
+            raise AuthenticationFailed("Found and invalid jws signature while decoding the access token.", "access_token_invalid_jws_signature") from err
+        except JWTExpired as err:
             raise AuthenticationFailed("Access token has expired.", "access_token_expired") from err
+        except JWTNotYetValid as err:
+            raise AuthenticationFailed("Access token not yet valid.", "access_token_not_yet_valid") from err
+        except Exception as err:
+            raise AuthenticationFailed("Unexpected error validating token.", "access_token_unexpected_error") from err
 
         return CERNKeycloakUser(token), token
 

--- a/backend/utils/rest_framework_cern_sso/backends.py
+++ b/backend/utils/rest_framework_cern_sso/backends.py
@@ -42,7 +42,7 @@ class CERNKeycloakOIDC:
     def get_device(self) -> dict:
         return self._kc.device()
 
-    def decode_token(self, token: str, options: dict) -> dict:
+    def decode_token(self, token: str) -> dict:
         if self.skip_pk is True:
             raise KeycloakClientError
         options = {"verify_signature": True, "verify_aud": True, "verify_exp": True}

--- a/backend/utils/rest_framework_cern_sso/token.py
+++ b/backend/utils/rest_framework_cern_sso/token.py
@@ -1,4 +1,6 @@
-from jose.jwt import get_unverified_claims
+import json
+
+from jwcrypto import jwt
 
 from .backends import CERNKeycloakOIDC
 from .exceptions import InvalidClient
@@ -8,7 +10,8 @@ class CERNKeycloakToken:
     def __init__(self, access_token: str, client: CERNKeycloakOIDC | None) -> None:
         self.access_token = access_token
         self.client = client
-        self.unv_claims = get_unverified_claims(access_token)
+        decoded_jwt = jwt.JWT(key=None, jwt=access_token)
+        self.unv_claims = json.loads(decoded_jwt.token.objects.get("payload").decode())
         self.aud = self.unv_claims["aud"]
         self.azp = self.unv_claims["azp"]
         self.claims = None
@@ -23,9 +26,7 @@ class CERNKeycloakToken:
     def decode_and_verify(self) -> None:
         if self.client is None:
             raise ValueError("Unconfigured keycloak client.")
-        self.claims = self.client.decode_token(
-            self.access_token, {"verify_signature": True, "verify_aud": True, "verify_exp": True}
-        )
+        self.claims = self.client.decode_token(self.access_token)
 
     def validate(self, valid_aud: list, valid_azp: list) -> None:
         self.check_parties(valid_aud, valid_azp)

--- a/poetry.lock
+++ b/poetry.lock
@@ -741,24 +741,6 @@ django = ">=3.0"
 pytz = "*"
 
 [[package]]
-name = "ecdsa"
-version = "0.18.0"
-description = "ECDSA cryptographic signature library (pure python)"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "ecdsa-0.18.0-py2.py3-none-any.whl", hash = "sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd"},
-    {file = "ecdsa-0.18.0.tar.gz", hash = "sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49"},
-]
-
-[package.dependencies]
-six = ">=1.9.0"
-
-[package.extras]
-gmpy = ["gmpy"]
-gmpy2 = ["gmpy2"]
-
-[[package]]
 name = "filelock"
 version = "3.13.1"
 description = "A platform independent file lock."
@@ -1009,6 +991,21 @@ files = [
     {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
     {file = "inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417"},
 ]
+
+[[package]]
+name = "jwcrypto"
+version = "1.5.6"
+description = "Implementation of JOSE Web standards"
+optional = false
+python-versions = ">= 3.8"
+files = [
+    {file = "jwcrypto-1.5.6-py3-none-any.whl", hash = "sha256:150d2b0ebbdb8f40b77f543fb44ffd2baeff48788be71f67f03566692fd55789"},
+    {file = "jwcrypto-1.5.6.tar.gz", hash = "sha256:771a87762a0c081ae6166958a954f80848820b2ab066937dc8b8379d65b1b039"},
+]
+
+[package.dependencies]
+cryptography = ">=3.4"
+typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "kiwisolver"
@@ -1741,17 +1738,6 @@ files = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.5.1"
-description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-files = [
-    {file = "pyasn1-0.5.1-py2.py3-none-any.whl", hash = "sha256:4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58"},
-    {file = "pyasn1-0.5.1.tar.gz", hash = "sha256:6d391a96e59b23130a5cfa74d6fd7f388dbbe26cc8f1edf39fdddf08d9d6676c"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -1828,40 +1814,19 @@ files = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.3.0"
-description = "JOSE implementation in Python"
-optional = false
-python-versions = "*"
-files = [
-    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
-    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
-]
-
-[package.dependencies]
-ecdsa = "!=0.15"
-pyasn1 = "*"
-rsa = "*"
-
-[package.extras]
-cryptography = ["cryptography (>=3.4.0)"]
-pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
-pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
-
-[[package]]
 name = "python-keycloak"
-version = "3.7.0"
+version = "3.12.0"
 description = "python-keycloak is a Python package providing access to the Keycloak API."
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = "<4.0,>=3.8"
 files = [
-    {file = "python_keycloak-3.7.0-py3-none-any.whl", hash = "sha256:92aa0a7e965cc5422d335c36efa0519f3188d9b8048cc8083f8f6e23c13178a5"},
-    {file = "python_keycloak-3.7.0.tar.gz", hash = "sha256:29eee9490ba354af81fcdf86ec81d840515d8b53002de831715e05d07298886a"},
+    {file = "python_keycloak-3.12.0-py3-none-any.whl", hash = "sha256:e8073515e6b47500cf0bda0d7eb8dd0cd2e83fa537196aed7c359dec15a2ee81"},
+    {file = "python_keycloak-3.12.0.tar.gz", hash = "sha256:21dec81992db192a462a6f12b792fd1c84d18d9bf5e91dea033a46e6f51b6694"},
 ]
 
 [package.dependencies]
 deprecation = ">=2.1.0"
-python-jose = ">=3.3.0"
+jwcrypto = ">=1.5.4,<2.0.0"
 requests = ">=2.20.0"
 requests-toolbelt = ">=0.6.0"
 
@@ -1991,20 +1956,6 @@ files = [
 
 [package.dependencies]
 requests = ">=2.0.1,<3.0.0"
-
-[[package]]
-name = "rsa"
-version = "4.9"
-description = "Pure-Python RSA implementation"
-optional = false
-python-versions = ">=3.6,<4"
-files = [
-    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
-    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
-]
-
-[package.dependencies]
-pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruff"
@@ -2334,4 +2285,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "1d24128f37558c66788f004220f29b9ad039eb279b13f660e627ad06f6194a1c"
+content-hash = "d3c25ceccb477e8ab773771a9326099325f8bf4c88b38c2e178689326987b9fe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,10 @@ django-csp = "^3.8"
 django-permissions-policy = "^4.19.0"
 dj-database-url = "^2.1.0"
 django-redis = "^5.4.0"
-python-keycloak = "^3.7.0"
+python-keycloak = "^3.12.0"
 uvicorn = "^0.27.0.post1"
 gunicorn = "^22.0.0"
+jwcrypto = "^1.5.6"
 
 [tool.poetry.group.etl.dependencies]
 celery = "^5.3.6"


### PR DESCRIPTION
- python-jose is not maintained for almost 3 years
- updating python-keycloak version to `3.12.0` removes dependencies on python-jose and ecdsa

Those removals fixed the following security issues:
- https://github.com/cms-DQM/dials/security/dependabot/21
- https://github.com/cms-DQM/dials/security/dependabot/20
- https://github.com/cms-DQM/dials/security/dependabot/7