### PR TITLE
refactor: update cache ttl default value to fix redis memory requests exceeded issue

### DIFF
--- a/backend/dials/settings.py
+++ b/backend/dials/settings.py
@@ -211,8 +211,17 @@ CSP_IMG_SRC = [
     "https://unpkg.com/swagger-ui-dist@5.11.0/favicon-32x32.png",
 ]
 
-# Caching
-CACHE_TTL = config("DJANGO_CACHE_TTL", cast=int, default=60 * 15)  # 15 minutes
+# -- Caching
+# If the CACHE TTL is too big you can have problems with Redis
+# since in production it is running in OC (Kubernetes) with a memory request limit
+# bigger ttl means more memory occupied for longer a longer period of time
+# and if we are receiving too much requests with different parameters (covered in the cache config for each route)
+# we can exceed the memory request limit and Redis will forcefully restart.
+# When Redis restart nginx hangs waiting the backend which hangs waiting for redis
+# which will cause timeout for the users (504 Gateway Time-out).
+# If we really need a bigger TTL, we need to check if we have enough memory available in the OC cluster
+# to increase Redis memory requests limit.
+CACHE_TTL = config("DJANGO_CACHE_TTL", cast=int, default=30)  # 30 seconds
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",

--- a/oc/prod/configmaps/backend.yaml
+++ b/oc/prod/configmaps/backend.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   DJANGO_ENV: prod
   DJANGO_DEBUG: '0'
+  DJANGO_CACHE_TTL: 30
   DJANGO_ALLOWED_HOSTS: cmsdials-api.web.cern.ch cmsdials.web.cern.ch
   DJANGO_CSRF_TRUSTED_ORIGINS: https://cmsdials-api.web.cern.ch https://cmsdials.web.cern.ch
   DJANGO_CORS_ALLOWED_ORIGINS: https://cmsdials-api.web.cern.ch https://cmsdials.web.cern.ch


### PR DESCRIPTION
- Update default CACHE_TTL value to 30 seconds
- Update backend configmap to force DJANGO_CACHE_TTL to 30 seconds and not rely on CACHE_TTL default value