### PR TITLE
chore: replace $APP_HOME from production frontend dockerfile with /usr/src/app/

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -11,8 +11,8 @@ COPY yarn.lock /usr/src/app/
 
 RUN yarn install
 
-COPY .eslintignore $APP_HOME
-COPY .eslintrc.js $APP_HOME
+COPY .eslintignore /usr/src/app/
+COPY .eslintrc.js /usr/src/app/
 COPY vite.config.mjs /usr/src/app/
 COPY frontend /usr/src/app/frontend
 


### PR DESCRIPTION
- Although build is working even if APP_HOME is not set in the container, it is a good idea to deploy this modification to keep code consistent