### PR TITLE
feat: add muon_staging workspace

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,7 +35,7 @@ RUN pip3 wheel --no-cache-dir --no-deps --wheel-dir /usr/src/build/wheels -r req
 FROM python:3.10.13-slim AS release
 
 # This is to print directly to stdout instead of buffering output
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 ARG UID=1000
 ARG GID=1000

--- a/etl/Dockerfile
+++ b/etl/Dockerfile
@@ -2,7 +2,7 @@
 # BASE IMAGE FOR OTHER STAGES
 ###############################
 
-FROM rootproject/root:6.30.02-ubuntu22.04 as base
+FROM rootproject/root:6.30.02-ubuntu22.04 AS base
 
 # The ROOT installed in the base image was compiled against python3 in ubuntu22.04 base image
 # ROOT's team just installed the latest python version (3.10.x) at build time
@@ -39,7 +39,7 @@ ENV PYTHONFAULTHANDLER=1 \
 # BUILDER IMAGE
 ###############################
 
-FROM base as builder
+FROM base AS builder
 
 WORKDIR /usr/src/app
 

--- a/etl/Dockerfile.prod
+++ b/etl/Dockerfile.prod
@@ -2,7 +2,7 @@
 # BASE IMAGE FOR OTHER STAGES
 ###############################
 
-FROM rootproject/root:6.30.02-ubuntu22.04 as base
+FROM rootproject/root:6.30.02-ubuntu22.04 AS base
 
 # The ROOT installed in the base image was compiled against python3 in ubuntu22.04 base image
 # ROOT's team just installed the latest python version (3.10.x) at build time
@@ -39,7 +39,7 @@ ENV PYTHONFAULTHANDLER=1 \
 # BUILDER IMAGE
 ###############################
 
-FROM base as builder
+FROM base AS builder
 
 WORKDIR /usr/src/app
 

--- a/etl/etl.config.json
+++ b/etl/etl.config.json
@@ -2,9 +2,6 @@
   "common_chunk_size": 5000,
   "common_indexer_queue": "common-indexer",
   "dev_env_label": "dev",
-  "downloader_bulk_suffix": "-downloader-bulk",
-  "downloader_priority_suffix": "-downloader-priority",
-  "era_cmp_pattern": "*Run202*",
   "priority_era": "Run2024",
   "th1_types": [3,4,5],
   "th2_types": [6,7,8],
@@ -13,72 +10,157 @@
     {
       "name": "csc",
       "primary_datasets": [
-        "Muon",
-        "Muon0",
-        "StreamExpress"
+        {
+          "dbs_pattern": "/Muon/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "Muon-downloader-bulk",
+          "priority_downloader_queue": "Muon-downloader-priority"
+        },
+        {
+          "dbs_pattern": "/Muon0/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "Muon0-downloader-bulk",
+          "priority_downloader_queue": "Muon0-downloader-priority"
+        },
+        {
+          "dbs_pattern": "/StreamExpress/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "StreamExpress-downloader-bulk",
+          "priority_downloader_queue": "StreamExpress-downloader-priority"
+        }
       ],
       "me_startswith": [
         "CSC/CSCOfflineMonitor/recHits/"
       ],
-      "bulk_queue": "csc-bulk",
-      "priority_queue": "csc-priority"
+      "bulk_ingesting_queue": "csc-bulk",
+      "priority_ingesting_queue": "csc-priority"
     },
     {
       "name": "ecal",
       "primary_datasets": [
-        "ZeroBias"
+        {
+          "dbs_pattern": "/ZeroBias/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "ZeroBias-downloader-bulk",
+          "priority_downloader_queue": "ZeroBias-downloader-priority"
+        }
       ],
       "me_startswith": [
         "EcalBarrel/",
         "EcalEndcap/",
         "Ecal/EventInfo/"
       ],
-      "bulk_queue": "ecal-bulk",
-      "priority_queue": "ecal-priority"
+      "bulk_ingesting_queue": "ecal-bulk",
+      "priority_ingesting_queue": "ecal-priority"
     },
     {
       "name": "egamma",
       "primary_datasets": [
-        "EGamma0"
+        {
+          "dbs_pattern": "/EGamma0/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "EGamma0-downloader-bulk",
+          "priority_downloader_queue": "EGamma0-downloader-priority"
+        }
       ],
       "me_startswith": [
         "Egamma/"
       ],
-      "bulk_queue": "egamma-bulk",
-      "priority_queue": "egamma-priority"
+      "bulk_ingesting_queue": "egamma-bulk",
+      "priority_ingesting_queue": "egamma-priority"
     },
     {
       "name": "hcal",
       "primary_datasets": [
-        "ZeroBias"
+        {
+          "dbs_pattern": "/ZeroBias/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "ZeroBias-downloader-bulk",
+          "priority_downloader_queue": "ZeroBias-downloader-priority"
+        }
       ],
       "me_startswith": [
         "Hcal/DigiTask/"
       ],
-      "bulk_queue": "hcal-bulk",
-      "priority_queue": "hcal-priority"
+      "bulk_ingesting_queue": "hcal-bulk",
+      "priority_ingesting_queue": "hcal-priority"
     },
     {
       "name": "jetmet",
       "primary_datasets": [
-        "JetMET",
-        "JetMET0"
+        {
+          "dbs_pattern": "/JetMET/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "JetMET-downloader-bulk",
+          "priority_downloader_queue": "JetMET-downloader-priority"
+        },
+        {
+          "dbs_pattern": "/JetMET0/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "JetMET0-downloader-bulk",
+          "priority_downloader_queue": "JetMET0-downloader-priority"
+        }
       ],
       "me_startswith": [
         "JetMET/Jet/",
         "JetMET/MET/"
       ],
-      "bulk_queue": "jetmet-bulk",
-      "priority_queue": "jetmet-priority"
+      "bulk_ingesting_queue": "jetmet-bulk",
+      "priority_ingesting_queue": "jetmet-priority"
+    },
+    {
+      "name": "muon_staging",
+      "primary_datasets": [
+        {
+          "dbs_pattern": "/ZeroBias/fsimone-crab_Run2023C-v1_DQMIO_ZeroBias_2023C_jun24-00000000000000000000000000000000/USER",
+          "dbs_instance": "phys03",
+          "bulk_downloader_queue": "Private-downloader-bulk",
+          "priority_downloader_queue": "Private-downloader-bulk"
+        }
+      ],
+      "me_startswith": [
+        "DT/02-Segments/Wheel-1/numberOfSegments_W-1",
+        "DT/02-Segments/Wheel-2/numberOfSegments_W-2",
+        "DT/02-Segments/Wheel0/numberOfSegments_W0",
+        "DT/02-Segments/Wheel1/numberOfSegments_W1",
+        "DT/02-Segments/Wheel2/numberOfSegments_W2"
+      ],
+      "bulk_ingesting_queue": "private-bulk",
+      "priority_ingesting_queue": "private-bulk"
     },
     {
       "name": "tracker",
       "primary_datasets": [
-        "ZeroBias",
-        "StreamExpress",
-        "HIForward0",
-        "HIPhysicsRawPrime0",
-        "StreamHIExpressRawPrime"
+        {
+          "dbs_pattern": "/ZeroBias/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "ZeroBias-downloader-bulk",
+          "priority_downloader_queue": "ZeroBias-downloader-priority"
+        },
+        {
+          "dbs_pattern": "/StreamExpress/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "StreamExpress-downloader-bulk",
+          "priority_downloader_queue": "StreamExpress-downloader-priority"
+        },
+        {
+          "dbs_pattern": "/HIForward0/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "HIForward0-downloader-bulk",
+          "priority_downloader_queue": "HIForward0-downloader-priority"
+        },
+        {
+          "dbs_pattern": "/HIPhysicsRawPrime0/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "HIPhysicsRawPrime0-downloader-bulk",
+          "priority_downloader_queue": "HIPhysicsRawPrime0-downloader-priority"
+        },
+        {
+          "dbs_pattern": "/StreamHIExpressRawPrime/*Run202*/DQMIO",
+          "dbs_instance": "global",
+          "bulk_downloader_queue": "StreamHIExpressRawPrime-downloader-bulk",
+          "priority_downloader_queue": "StreamHIExpressRawPrime-downloader-priority"
+        }
       ],
       "me_startswith": [
         "PixelPhase1/",
@@ -117,8 +199,8 @@
         "OfflinePV/offlinePrimaryVertices/tagDiffX",
         "OfflinePV/offlinePrimaryVertices/tagDiffY"
       ],
-      "bulk_queue": "tracker-bulk",
-      "priority_queue": "tracker-priority"
+      "bulk_ingesting_queue": "tracker-bulk",
+      "priority_ingesting_queue": "tracker-priority"
     }
   ]
 }

--- a/etl/python/common/dbs_client.py
+++ b/etl/python/common/dbs_client.py
@@ -10,15 +10,17 @@ TIMEOUT = 30
 
 
 class MinimalDBSClient:
-    API_URL = "https://cmsweb-prod.cern.ch:8443/dbs/prod/global/DBSReader"
+    BASE_URL = "https://cmsweb-prod.cern.ch:8443/dbs/prod"
 
     def __init__(
         self,
+        dbs_instance: str | None = "global",
         cert_fpath: str | None = None,
         key_fpath: str | None = None,
         use_mock: bool = False,
         mock_fpath: str | None = None,
     ) -> None:
+        self.reader_url = os.path.join(self.BASE_URL, dbs_instance, "DBSReader")
         self.cert_fpath = cert_fpath
         self.key_fpath = key_fpath  # This key should be open
         self.use_mock = use_mock
@@ -34,7 +36,7 @@ class MinimalDBSClient:
         if self.cert_fpath is None or self.key_fpath is None:
             raise ValueError("Cert or key file path not set")
 
-        url = os.path.join(self.API_URL, endpoint)
+        url = os.path.join(self.reader_url, endpoint)
         cert = (self.cert_fpath, self.key_fpath)
         try:
             response = requests.get(url, params=params, cert=cert, timeout=TIMEOUT)

--- a/etl/python/config.py
+++ b/etl/python/config.py
@@ -25,7 +25,7 @@ workspaces = config_contents["workspaces"]
 # List all primary datasets (removing duplicates)
 primary_datasets = [obj for ws in workspaces for obj in ws["primary_datasets"]]
 primary_datasets = {(d["dbs_pattern"], d["dbs_instance"]): d for d in primary_datasets}.values()
-primary_datasets = sorted(primary_datasets, key=lambda x: x["name"])
+primary_datasets = sorted(primary_datasets, key=lambda x: x["dbs_pattern"])
 
 # We can delete config_contents from memory
 del config_contents

--- a/etl/python/config.py
+++ b/etl/python/config.py
@@ -16,26 +16,16 @@ with open(etl_config_fpath) as f:
 common_chunk_size = config_contents["common_chunk_size"]
 common_indexer_queue = config_contents["common_indexer_queue"]
 dev_env_label = config_contents["dev_env_label"]
-downloader_bulk_suffix = config_contents["downloader_bulk_suffix"]
-downloader_priority_suffix = config_contents["downloader_priority_suffix"]
 priority_era = config_contents["priority_era"]
 th1_types = config_contents["th1_types"]
 th2_types = config_contents["th2_types"]
 th2_chunk_size = config_contents["th2_chunk_size"]
 workspaces = config_contents["workspaces"]
 
-# List all primary datasets (removing duplicates) and generate queue names
+# List all primary datasets (removing duplicates)
 primary_datasets = [obj for ws in workspaces for obj in ws["primary_datasets"]]
-primary_datasets = {(d["name"], d["dbs_pattern"], d["dbs_instance"]): d for d in primary_datasets}.values()
+primary_datasets = {(d["dbs_pattern"], d["dbs_instance"]): d for d in primary_datasets}.values()
 primary_datasets = sorted(primary_datasets, key=lambda x: x["name"])
-unique_pds = sorted(set([pd["name"] for pd in primary_datasets]))
-pds_queues = {
-    primary_dataset: {
-        "bulk_queue": f"{primary_dataset}{downloader_bulk_suffix}",
-        "priority_queue": f"{primary_dataset}{downloader_priority_suffix}",
-    }
-    for primary_dataset in unique_pds
-}
 
 # We can delete config_contents from memory
 del config_contents

--- a/etl/python/config.py
+++ b/etl/python/config.py
@@ -18,22 +18,23 @@ common_indexer_queue = config_contents["common_indexer_queue"]
 dev_env_label = config_contents["dev_env_label"]
 downloader_bulk_suffix = config_contents["downloader_bulk_suffix"]
 downloader_priority_suffix = config_contents["downloader_priority_suffix"]
-era_cmp_pattern = config_contents["era_cmp_pattern"]
 priority_era = config_contents["priority_era"]
 th1_types = config_contents["th1_types"]
 th2_types = config_contents["th2_types"]
 th2_chunk_size = config_contents["th2_chunk_size"]
 workspaces = config_contents["workspaces"]
 
-# List all primary datasets and generate queue names
-primary_datasets = [elem for ws in workspaces for elem in ws["primary_datasets"]]
-primary_datasets = sorted(set(primary_datasets))
+# List all primary datasets (removing duplicates) and generate queue names
+primary_datasets = [obj for ws in workspaces for obj in ws["primary_datasets"]]
+primary_datasets = {(d["name"], d["dbs_pattern"], d["dbs_instance"]): d for d in primary_datasets}.values()
+primary_datasets = sorted(primary_datasets, key=lambda x: x["name"])
+unique_pds = sorted(set([pd["name"] for pd in primary_datasets]))
 pds_queues = {
     primary_dataset: {
         "bulk_queue": f"{primary_dataset}{downloader_bulk_suffix}",
         "priority_queue": f"{primary_dataset}{downloader_priority_suffix}",
     }
-    for primary_dataset in primary_datasets
+    for primary_dataset in unique_pds
 }
 
 # We can delete config_contents from memory

--- a/etl/python/pipelines/dataset_indexer/extract.py
+++ b/etl/python/pipelines/dataset_indexer/extract.py
@@ -1,9 +1,9 @@
 from ...common.dbs_client import MinimalDBSClient
-from ...config import era_cmp_pattern
 from ...env import cert_fpath, key_fpath
 
 
-def extract(primary_dataset: str) -> list:
-    dbs = MinimalDBSClient(cert_fpath, key_fpath)
-    dt_pattern = f"/{primary_dataset}/{era_cmp_pattern}/DQMIO"
-    return dbs.get(endpoint="datasets", params={"dataset": dt_pattern, "detail": 1, "dataset_access_type": "*"})
+def extract(primary_dataset: dict) -> list:
+    dbs = MinimalDBSClient(primary_dataset["dbs_instance"], cert_fpath, key_fpath)
+    return dbs.get(
+        endpoint="datasets", params={"dataset": primary_dataset["dbs_pattern"], "detail": 1, "dataset_access_type": "*"}
+    )

--- a/etl/python/pipelines/file_downloader/pipeline.py
+++ b/etl/python/pipelines/file_downloader/pipeline.py
@@ -39,11 +39,11 @@ def pipeline(
 
     for ws in wss:
         post_download(engines[ws["name"]], file_id)
-        queue_name = ws["p_queue"] if priority_era in logical_file_name else ws["b_queue"]
+        queue_name = ws["priority_ingesting_queue"] if priority_era in logical_file_name else ws["bulk_ingesting_queue"]
         kwargs = {
             "file_id": file_id,
             "dataset_id": dataset_id,
             "workspace_name": ws["name"],
-            "workspace_mes": ws["mes"],
+            "workspace_mes": ws["me_startswith"],
         }
         file_ingesting_pipeline_task.apply_async(kwargs=kwargs, queue=queue_name)

--- a/etl/python/pipelines/file_indexer/extract.py
+++ b/etl/python/pipelines/file_indexer/extract.py
@@ -2,20 +2,19 @@ from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm import sessionmaker
 
 from ...common.dbs_client import MinimalDBSClient
-from ...config import dev_env_label, era_cmp_pattern
+from ...config import dev_env_label
 from ...env import app_env, cert_fpath, key_fpath, mocked_dbs_fpath
 from ...models import FactDatasetIndex
 from ..utils import sqlachemy_asdict
 
 
-def extract(primary_dataset: str) -> list:
+def extract(primary_dataset: dict) -> list:
     dbs = (
-        MinimalDBSClient(cert_fpath, key_fpath)
+        MinimalDBSClient(primary_dataset["dbs_instance"], cert_fpath, key_fpath)
         if app_env != dev_env_label
-        else MinimalDBSClient(None, None, True, mocked_dbs_fpath)
+        else MinimalDBSClient("fake", None, None, True, mocked_dbs_fpath)
     )
-    dt_pattern = f"/{primary_dataset}/{era_cmp_pattern}/DQMIO"
-    return dbs.get(endpoint="files", params={"dataset": dt_pattern, "detail": 1})
+    return dbs.get(endpoint="files", params={"dataset": primary_dataset["dbs_pattern"], "detail": 1})
 
 
 def extract_datasets_ids(engine: Engine) -> dict:

--- a/etl/python/pipelines/file_indexer/pipeline.py
+++ b/etl/python/pipelines/file_indexer/pipeline.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from sqlalchemy import create_engine
 
-from ...config import pds_queues, priority_era
+from ...config import priority_era
 from ...env import conn_str
 from ..file_downloader.tasks import file_downloader_pipeline_task
 from .extract import extract, extract_datasets_ids
@@ -37,8 +37,10 @@ def pipeline(workspaces: list, primary_datasets: list) -> None:
         # Schedule download tasks for multiple workspaces that share the same PD
         inserted_files: list = file_index[file_index.file_id.isin(list(wss_by_id.keys()))].to_dict(orient="records")
         for file in inserted_files:
-            queue_key = "priority_queue" if priority_era in file["logical_file_name"] else "bulk_queue"
-            queue_name = pds_queues[primary_dataset["name"]][queue_key]
+            queue_key = (
+                "priority_downloader_queue" if priority_era in file["logical_file_name"] else "bulk_downloader_queue"
+            )
+            queue_name = primary_dataset[queue_key]
             file_downloader_pipeline_task.apply_async(
                 kwargs={
                     "dataset_id": file["dataset_id"],
@@ -47,9 +49,15 @@ def pipeline(workspaces: list, primary_datasets: list) -> None:
                     "wss": [
                         {
                             "name": ws_name,
-                            "mes": next(filter(lambda x: x["name"] == ws_name, workspaces), None)["me_startswith"],
-                            "p_queue": next(filter(lambda x: x["name"] == ws_name, workspaces), None)["priority_queue"],
-                            "b_queue": next(filter(lambda x: x["name"] == ws_name, workspaces), None)["bulk_queue"],
+                            "me_startswith": next(filter(lambda x: x["name"] == ws_name, workspaces), None)[
+                                "me_startswith"
+                            ],
+                            "priority_ingesting_queue": next(filter(lambda x: x["name"] == ws_name, workspaces), None)[
+                                "priority_ingesting_queue"
+                            ],
+                            "bulk_ingesting_queue": next(filter(lambda x: x["name"] == ws_name, workspaces), None)[
+                                "bulk_ingesting_queue"
+                            ],
                         }
                         for ws_name in wss_by_id[file["file_id"]]
                     ],

--- a/etl/python/pipelines/file_indexer/pipeline.py
+++ b/etl/python/pipelines/file_indexer/pipeline.py
@@ -38,7 +38,7 @@ def pipeline(workspaces: list, primary_datasets: list) -> None:
         inserted_files: list = file_index[file_index.file_id.isin(list(wss_by_id.keys()))].to_dict(orient="records")
         for file in inserted_files:
             queue_key = "priority_queue" if priority_era in file["logical_file_name"] else "bulk_queue"
-            queue_name = pds_queues[primary_dataset][queue_key]
+            queue_name = pds_queues[primary_dataset["name"]][queue_key]
             file_downloader_pipeline_task.apply_async(
                 kwargs={
                     "dataset_id": file["dataset_id"],

--- a/etl/scripts/start-dev.sh
+++ b/etl/scripts/start-dev.sh
@@ -20,7 +20,7 @@ fi
 pds_names=()
 while IFS= read -r dataset; do
     pds_names+=("$dataset")
-done < <(jq -r '.workspaces[].primary_datasets[]' "$ETL_CONFIG_FPATH" | sort -u)
+done < <(jq -r '.workspaces[].primary_datasets[].name' "$ETL_CONFIG_FPATH" | sort -u)
 
 # Parse databases set in environment
 databases_parsed=$(echo $DATABASES | sed 's/[ ][ ]*//g')

--- a/etl/scripts/start-dev.sh
+++ b/etl/scripts/start-dev.sh
@@ -16,15 +16,31 @@ else
     exit 1
 fi
 
-# Primary dataset download queue
-pds_names=()
-while IFS= read -r dataset; do
-    pds_names+=("$dataset")
-done < <(jq -r '.workspaces[].primary_datasets[].name' "$ETL_CONFIG_FPATH" | sort -u)
+# Primary datasets download queues
+downloader_queues=()
 
-# Parse databases set in environment
-databases_parsed=$(echo $DATABASES | sed 's/[ ][ ]*//g')
-IFS=',' read -r -a db_names <<< "$databases_parsed"
+while IFS= read -r queue_name; do
+    downloader_queues+=("$queue_name")
+done < <(jq -r '.workspaces[].primary_datasets[].bulk_downloader_queue' "$ETL_CONFIG_FPATH" | sort -u)
+
+while IFS= read -r queue_name; do
+    downloader_queues+=("$queue_name")
+done < <(jq -r '.workspaces[].primary_datasets[].priority_downloader_queue' "$ETL_CONFIG_FPATH" | sort -u)
+
+downloader_queues=($(printf "%s\n" "${downloader_queues[@]}" | sort -u))
+
+# Ingesting queues
+ingesting_queues=()
+
+while IFS= read -r queue_name; do
+    ingesting_queues+=("$queue_name")
+done < <(jq -r '.workspaces[].bulk_ingesting_queue' "$ETL_CONFIG_FPATH" | sort -u)
+
+while IFS= read -r queue_name; do
+    ingesting_queues+=("$queue_name")
+done < <(jq -r '.workspaces[].priority_ingesting_queue' "$ETL_CONFIG_FPATH" | sort -u)
+
+ingesting_queues=($(printf "%s\n" "${ingesting_queues[@]}" | sort -u))
 
 # Array of pids to wait
 pids_arr=()
@@ -38,18 +54,14 @@ poetry run celery --app=python worker --loglevel=INFO --concurrency=1 --autoscal
 pids_arr+=($!)
 
 # Start workers for each workspace
-for db_name in "${db_names[@]}"; do
-    poetry run celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname=${db_name}-bulk@%h --queues=${db_name}-bulk &
-    pids_arr+=($!)
-    poetry run celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname=${db_name}-priority@%h --queues=${db_name}-priority &
+for queue_name in "${ingesting_queues[@]}"; do
+    poetry run celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname=${queue_name}@%h --queues=${queue_name} &
     pids_arr+=($!)
 done
 
 # Start downloader workers for each pd
-for pd_name in "${pds_names[@]}"; do
-    poetry run celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname=${pd_name}-downloader-bulk@%h --queues=${pd_name}-downloader-bulk &
-    pids_arr+=($!)
-    poetry run celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname=${pd_name}-downloader-priority@%h --queues=${pd_name}-downloader-priority &
+for queue_name in "${downloader_queues[@]}"; do
+    poetry run celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname=${queue_name}@%h --queues=${queue_name} &
     pids_arr+=($!)
 done
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,7 @@
 # BUILDER IMAGE
 ###############################
 
-FROM node:20.11-bookworm as builder
+FROM node:20.11-bookworm AS builder
 
 WORKDIR /usr/src/app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,7 +2,7 @@
 # BUILDER IMAGE
 ###############################
 
-FROM node:20.11-bookworm as builder
+FROM node:20.11-bookworm AS builder
 
 WORKDIR /usr/src/app
 

--- a/oc/prod/deployments/etl/downloaders/private.yaml
+++ b/oc/prod/deployments/etl/downloaders/private.yaml
@@ -1,0 +1,69 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: private-downloader-bulk
+  namespace: cms-dials-prod
+  labels:
+    app: private-downloader-bulk
+    app.kubernetes.io/component: private-downloader-bulk
+    app.kubernetes.io/instance: private-downloader-bulk
+    app.kubernetes.io/name: private-downloader-bulk
+    app.kubernetes.io/part-of: private-downloader
+    app.openshift.io/runtime: python
+    app.openshift.io/runtime-namespace: cms-dials-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: private-downloader-bulk
+  template:
+    metadata:
+      labels:
+        app: private-downloader-bulk
+        deployment: private-downloader-bulk
+      annotations:
+        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
+    spec:
+      volumes:
+        - name: eos-storage
+          persistentVolumeClaim:
+            claimName: eos-storage
+      containers:
+        - name: private-downloader-bulk
+          resources:
+            requests:
+              memory: 256Mi
+            limits:
+              memory: 1024Mi
+          command:
+            - bash
+            - '-c'
+            - >-
+              celery --app=python worker --loglevel=INFO --concurrency=1
+              --autoscale=1,0 --max-tasks-per-child=1 --hostname=Private-downloader-bulk@%h
+              --queues=Private-downloader-bulk
+          envFrom:
+            - configMapRef:
+                name: dials-etl-configmap
+            - secretRef:
+                name: dials-etl-secrets
+            - secretRef:
+                name: eos-credentials
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: eos-storage
+              readOnly: true
+              mountPath: /eos
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/cms-dials-prod/etl:latest
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/oc/prod/deployments/etl/workspaces/private.yaml
+++ b/oc/prod/deployments/etl/workspaces/private.yaml
@@ -1,0 +1,69 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: private-bulk
+  namespace: cms-dials-prod
+  labels:
+    app: private-bulk
+    app.kubernetes.io/component: private-bulk
+    app.kubernetes.io/instance: private-bulk
+    app.kubernetes.io/name: private-bulk
+    app.kubernetes.io/part-of: private-etl
+    app.openshift.io/runtime: python
+    app.openshift.io/runtime-namespace: cms-dials-prod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: private-bulk
+  template:
+    metadata:
+      labels:
+        app: private-bulk
+        deployment: private-bulk
+      annotations:
+        eos.okd.cern.ch/mount-eos-with-credentials-from-secret: eos-credentials
+    spec:
+      volumes:
+        - name: eos-storage
+          persistentVolumeClaim:
+            claimName: eos-storage
+      containers:
+        - name: private-bulk
+          resources:
+            requests:
+              memory: 1024Mi
+            limits:
+              memory: 5120Mi
+          command:
+            - bash
+            - '-c'
+            - >-
+              celery --app=python worker --loglevel=INFO --concurrency=1
+              --autoscale=1,0 --max-tasks-per-child=1 --hostname=private-bulk@%h
+              --queues=private-bulk
+          envFrom:
+            - configMapRef:
+                name: dials-etl-configmap
+            - secretRef:
+                name: dials-etl-secrets
+            - secretRef:
+                name: eos-credentials
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: eos-storage
+              readOnly: true
+              mountPath: /eos
+          image: >-
+            image-registry.openshift-image-registry.svc:5000/cms-dials-prod/etl:latest
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/scripts/gencompose-network-host.py
+++ b/scripts/gencompose-network-host.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
 
     # Primary datasets configured
     with open(etl_config_fpath) as f:
-        primary_datasets = [elem for ws in json.load(f)["workspaces"] for elem in ws["primary_datasets"]]
+        primary_datasets = [elem.get("name") for ws in json.load(f)["workspaces"] for elem in ws["primary_datasets"]]
         primary_datasets = sorted(set(primary_datasets))
 
     comments = """# Notes

--- a/scripts/gencompose-network-host.py
+++ b/scripts/gencompose-network-host.py
@@ -3,7 +3,6 @@
 import argparse
 import json
 import os
-import re
 
 import yaml
 from decouple import Config, RepositoryEnv
@@ -126,42 +125,26 @@ def gen_compose_header(paths_to_mount):
     }
 
 
-def gen_compose_workspace_workers(paths_to_mount, db_name):
+def gen_compose_workspace_workers(paths_to_mount, queue_name):
     return {
-        f"dials-{db_name}-bulk": {
-            "container_name": f"dials-{db_name}-bulk",
+        f"dials-{queue_name}": {
+            "container_name": f"dials-{queue_name}",
             "image": "dials_etl",
             "volumes": gen_volumes(paths_to_mount),
-            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={db_name}-bulk@%h --queues={db_name}-bulk'",
-            "network_mode": "host",
-            "depends_on": gen_common_depends_on(),
-        },
-        f"dials-{db_name}-priority": {
-            "container_name": f"dials-{db_name}-priority",
-            "image": "dials_etl",
-            "volumes": gen_volumes(paths_to_mount),
-            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={db_name}-priority@%h --queues={db_name}-priority'",
+            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={queue_name}@%h --queues={queue_name}'",
             "network_mode": "host",
             "depends_on": gen_common_depends_on(),
         },
     }
 
 
-def gen_compose_downloader_workers(paths_to_mount, pd_name):
+def gen_compose_downloader_workers(paths_to_mount, queue_name):
     return {
-        f"dials-{pd_name.lower()}-downloader-bulk": {
-            "container_name": f"dials-{pd_name.lower()}-downloader-bulk",
+        f"dials-{queue_name.lower()}": {
+            "container_name": f"dials-{queue_name.lower()}",
             "image": "dials_etl",
             "volumes": gen_volumes(paths_to_mount),
-            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={pd_name}-downloader-bulk@%h --queues={pd_name}-downloader-bulk'",
-            "network_mode": "host",
-            "depends_on": gen_common_depends_on(),
-        },
-        f"dials-{pd_name.lower()}-downloader-priority": {
-            "container_name": f"dials-{pd_name.lower()}-downloader-priority",
-            "image": "dials_etl",
-            "volumes": gen_volumes(paths_to_mount),
-            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={pd_name}-downloader-priority@%h --queues={pd_name}-downloader-priority'",
+            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={queue_name}@%h --queues={queue_name}'",
             "network_mode": "host",
             "depends_on": gen_common_depends_on(),
         },
@@ -178,11 +161,8 @@ if __name__ == "__main__":
     parser.add_argument("--etl-env-file", help="Path to etl .env file.", default=f"{cwd}/etl/.env")
     args = parser.parse_args()
 
+    # Load .env
     config = Config(RepositoryEnv(args.etl_env_file))
-
-    # Databases configured
-    databases = config.get("DATABASES")
-    databases = re.sub("\s+", "", databases).split(",")
 
     # ETL paths to mount in docker
     etl_config_fpath = config.get("ETL_CONFIG_FPATH")
@@ -195,10 +175,20 @@ if __name__ == "__main__":
     ]
     paths_to_mount = [elem for elem in paths_to_mount if elem is not None]
 
-    # Primary datasets configured
+    # Queues
+    downloader_queues = []
+    ingesting_queues = []
     with open(etl_config_fpath) as f:
-        primary_datasets = [elem.get("name") for ws in json.load(f)["workspaces"] for elem in ws["primary_datasets"]]
-        primary_datasets = sorted(set(primary_datasets))
+        config_asjson = json.load(f)
+        for workspace in config_asjson["workspaces"]:
+            ingesting_queues.append(workspace["bulk_ingesting_queue"])
+            ingesting_queues.append(workspace["priority_ingesting_queue"])
+            for primary_dataset in workspace["primary_datasets"]:
+                downloader_queues.append(primary_dataset["bulk_downloader_queue"])
+                downloader_queues.append(primary_dataset["priority_downloader_queue"])
+
+    downloader_queues = sorted(set(downloader_queues))
+    ingesting_queues = sorted(set(ingesting_queues))
 
     comments = """# Notes
 #
@@ -214,12 +204,12 @@ if __name__ == "__main__":
 
     docker_compose = gen_compose_header(paths_to_mount)
 
-    for db_name in databases:
-        services = gen_compose_workspace_workers(paths_to_mount, db_name)
+    for queue_name in ingesting_queues:
+        services = gen_compose_workspace_workers(paths_to_mount, queue_name)
         docker_compose["services"].update(services)
 
-    for pd_name in primary_datasets:
-        services = gen_compose_downloader_workers(paths_to_mount, pd_name)
+    for queue_name in downloader_queues:
+        services = gen_compose_downloader_workers(paths_to_mount, queue_name)
         docker_compose["services"].update(services)
 
     with open("docker-compose.yaml", "w") as f:

--- a/scripts/gencompose-self-contained.py
+++ b/scripts/gencompose-self-contained.py
@@ -230,7 +230,7 @@ if __name__ == "__main__":
 
     # Primary datasets configured
     with open(etl_config_fpath) as f:
-        primary_datasets = [elem for ws in json.load(f)["workspaces"] for elem in ws["primary_datasets"]]
+        primary_datasets = [elem.get("name") for ws in json.load(f)["workspaces"] for elem in ws["primary_datasets"]]
         primary_datasets = sorted(set(primary_datasets))
 
     comments = """# Notes

--- a/scripts/gencompose-self-contained.py
+++ b/scripts/gencompose-self-contained.py
@@ -3,7 +3,6 @@
 import argparse
 import json
 import os
-import re
 
 import yaml
 from decouple import Config, RepositoryEnv
@@ -158,39 +157,25 @@ def gen_compose_header(postgres_path, paths_to_mount):
     }
 
 
-def gen_compose_workspace_workers(paths_to_mount, db_name):
+def gen_compose_workspace_workers(paths_to_mount, queue_name):
     return {
-        f"dials-{db_name}-bulk": {
-            "container_name": f"dials-{db_name}-bulk",
+        f"dials-{queue_name}": {
+            "container_name": f"dials-{queue_name}",
             "image": "dials_etl",
             "volumes": gen_volumes(paths_to_mount),
-            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={db_name}-bulk@%h --queues={db_name}-bulk'",
-            "depends_on": gen_common_depends_on(),
-        },
-        f"dials-{db_name}-priority": {
-            "container_name": f"dials-{db_name}-priority",
-            "image": "dials_etl",
-            "volumes": gen_volumes(paths_to_mount),
-            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={db_name}-priority@%h --queues={db_name}-priority'",
+            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={queue_name}@%h --queues={queue_name}'",
             "depends_on": gen_common_depends_on(),
         },
     }
 
 
-def gen_compose_downloader_workers(paths_to_mount, pd_name):
+def gen_compose_downloader_workers(paths_to_mount, queue_name):
     return {
-        f"dials-{pd_name.lower()}-downloader-bulk": {
-            "container_name": f"dials-{pd_name.lower()}-downloader-bulk",
+        f"dials-{queue_name.lower()}": {
+            "container_name": f"dials-{queue_name.lower()}",
             "image": "dials_etl",
             "volumes": gen_volumes(paths_to_mount),
-            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={pd_name}-downloader-bulk@%h --queues={pd_name}-downloader-bulk'",
-            "depends_on": gen_common_depends_on(),
-        },
-        f"dials-{pd_name.lower()}-downloader-priority": {
-            "container_name": f"dials-{pd_name.lower()}-downloader-priority",
-            "image": "dials_etl",
-            "volumes": gen_volumes(paths_to_mount),
-            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={pd_name}-downloader-priority@%h --queues={pd_name}-downloader-priority'",
+            "command": f"bash -c 'celery --app=python worker --loglevel=INFO --concurrency=1 --autoscale=1,0 --max-tasks-per-child=1 --hostname={queue_name}@%h --queues={queue_name}'",
             "depends_on": gen_common_depends_on(),
         },
     }
@@ -213,10 +198,6 @@ if __name__ == "__main__":
     # Load ETL env variables
     config = Config(RepositoryEnv(args.etl_env_file))
 
-    # Databases configured
-    databases = config.get("DATABASES")
-    databases = re.sub("\s+", "", databases).split(",")
-
     # ETL paths to mount in docker
     etl_config_fpath = config.get("ETL_CONFIG_FPATH")
     paths_to_mount = [
@@ -228,10 +209,20 @@ if __name__ == "__main__":
     ]
     paths_to_mount = [elem for elem in paths_to_mount if elem is not None]
 
-    # Primary datasets configured
+    # Queues
+    downloader_queues = []
+    ingesting_queues = []
     with open(etl_config_fpath) as f:
-        primary_datasets = [elem.get("name") for ws in json.load(f)["workspaces"] for elem in ws["primary_datasets"]]
-        primary_datasets = sorted(set(primary_datasets))
+        config_asjson = json.load(f)
+        for workspace in config_asjson["workspaces"]:
+            ingesting_queues.append(workspace["bulk_ingesting_queue"])
+            ingesting_queues.append(workspace["priority_ingesting_queue"])
+            for primary_dataset in workspace["primary_datasets"]:
+                downloader_queues.append(primary_dataset["bulk_downloader_queue"])
+                downloader_queues.append(primary_dataset["priority_downloader_queue"])
+
+    downloader_queues = sorted(set(downloader_queues))
+    ingesting_queues = sorted(set(ingesting_queues))
 
     comments = """# Notes
 #
@@ -241,12 +232,12 @@ if __name__ == "__main__":
 
     docker_compose = gen_compose_header(args.pg_persistent_path, paths_to_mount)
 
-    for db_name in databases:
-        services = gen_compose_workspace_workers(paths_to_mount, db_name)
+    for queue_name in ingesting_queues:
+        services = gen_compose_workspace_workers(paths_to_mount, queue_name)
         docker_compose["services"].update(services)
 
-    for pd_name in primary_datasets:
-        services = gen_compose_downloader_workers(paths_to_mount, pd_name)
+    for queue_name in downloader_queues:
+        services = gen_compose_downloader_workers(paths_to_mount, queue_name)
         docker_compose["services"].update(services)
 
     with open("docker-compose.yaml", "w") as f:


### PR DESCRIPTION
This was a tricky implementation, because the `muon_staging` workspace is meant to ingest privately produced datasets (used to test the new detector, for example). Those datasets are available on DBS instance `phys03` and DIALS only supported retrieving data from the `global` instance, therefore a small refactor was needed to allow fetching datasets from different instances.

The biggest change was the `etl.config.json` that has a bunch of new metadata to allow this feature generally, so every other pipeline or script that used this file had to be adapted to the new format.