### PR TITLE
Retry file downloader pipeline on lxplus authentication timeout + minor cli fixes

### DIFF
--- a/etl/cli.py
+++ b/etl/cli.py
@@ -60,11 +60,15 @@ def downloader_handler(args):
             wss_by_id[file_id]["logical_file_name"] = result["logical_file_name"]
 
     for file_id, item in wss_by_id.items():
+        first_ws = next(filter(lambda x: x["name"] == item["wss"][0], workspaces), None)
         queue_key = (
             "priority_downloader_queue" if priority_era in item["logical_file_name"] else "bulk_downloader_queue"
         )
         primary_dataset = item["logical_file_name"].split("/")[4]
-        queue_name = primary_dataset[queue_key]
+        queue_name = next(filter(lambda x: primary_dataset in x["dbs_pattern"], first_ws["primary_datasets"]), None)[
+            queue_key
+        ]
+        print(item["logical_file_name"], "-", queue_name, "-")
         file_downloader_pipeline_task.apply_async(
             kwargs={
                 "dataset_id": item["dataset_id"],
@@ -73,7 +77,9 @@ def downloader_handler(args):
                 "wss": [
                     {
                         "name": ws_name,
-                        "mes": next(filter(lambda x: x["name"] == ws_name, workspaces), None)["me_startswith"],
+                        "me_startswith": next(filter(lambda x: x["name"] == ws_name, workspaces), None)[
+                            "me_startswith"
+                        ],
                         "priority_ingesting_queue": next(filter(lambda x: x["name"] == ws_name, workspaces), None)[
                             "priority_ingesting_queue"
                         ],

--- a/etl/cli.py
+++ b/etl/cli.py
@@ -68,7 +68,6 @@ def downloader_handler(args):
         queue_name = next(filter(lambda x: primary_dataset in x["dbs_pattern"], first_ws["primary_datasets"]), None)[
             queue_key
         ]
-        print(item["logical_file_name"], "-", queue_name, "-")
         file_downloader_pipeline_task.apply_async(
             kwargs={
                 "dataset_id": item["dataset_id"],

--- a/etl/cli.py
+++ b/etl/cli.py
@@ -108,9 +108,9 @@ def ingesting_handler(args):
 
     tasks = [
         {
-            "queue_name": workspace["priority_queue"]
+            "queue_name": workspace["priority_ingesting_queue"]
             if priority_era in file["logical_file_name"]
-            else workspace["bulk_queue"],
+            else workspace["bulk_ingesting_queue"],
             "file_id": file["file_id"],
             "dataset_id": file["dataset_id"],
             "workspace_name": workspace["name"],

--- a/etl/python/common/lxplus_client.py
+++ b/etl/python/common/lxplus_client.py
@@ -2,6 +2,10 @@ import paramiko
 from scp import SCPClient
 
 
+class SSHAuthenticationTimeoutError(Exception):
+    pass
+
+
 class XrdcpNoServersAvailableToReadFileError(Exception):
     pass
 

--- a/etl/python/pipelines/file_downloader/tasks.py
+++ b/etl/python/pipelines/file_downloader/tasks.py
@@ -1,14 +1,11 @@
 from ...celery import app
-from ...common.lxplus_client import XrdcpTimeoutError, XrdcpUnknownError
+from ...common.lxplus_client import SSHAuthenticationTimeoutError, XrdcpTimeoutError, XrdcpUnknownError
 from .pipeline import pipeline
 
 
 @app.task(
     name="file_downloader_pipeline",
-    autoretry_for=(
-        XrdcpTimeoutError,
-        XrdcpUnknownError,
-    ),
+    autoretry_for=(SSHAuthenticationTimeoutError, XrdcpTimeoutError, XrdcpUnknownError),
     retry_kwargs={"max_retries": 5},
     retry_backoff=True,
 )


### PR DESCRIPTION
- Verify if paramiko connection failed because of authentication timeout and retry the pipeline up to 5 times;
- Minor cli fixes in ingesting and downloader methods