### PR TITLE
fix: check user e-groups against confidential token instead of public token

### DIFF
--- a/backend/cern_auth/viewsets.py
+++ b/backend/cern_auth/viewsets.py
@@ -51,9 +51,15 @@ class AuthViewSet(ViewSet):
         authentication_classes=[CERNKeycloakPublicAuthentication],
     )
     def exchange_token(self, request: Request):
+        # This user authenticated trough the CERNKeycloakPublicAuthentication
+        # already carries the public access token (subject_token) in the user object
+        # so we don't need to ask a subject token trough the request body
         user: CERNKeycloakUser = request.user
         subject_token = user.token.access_token
         confidential_token = user.token.client.exchange_token(subject_token, settings.KEYCLOAK_CONFIDENTIAL_CLIENT_ID)
+
+        # After exchanging the token we must decode it (we don't need to verify it since is was just issued by the auth server)
+        # and extract the proper cern_roles from the confidential token
         exc_token_obj = CERNKeycloakToken(confidential_token["access_token"], client=None)
         cern_roles = exc_token_obj.unv_claims.get("cern_roles")
         confidential_token["default_workspace"] = get_workspace_from_role(cern_roles, use_default_if_not_found=True)

--- a/backend/static/swagger.json
+++ b/backend/static/swagger.json
@@ -65,19 +65,7 @@
         "parameters": [],
         "requestBody": {
           "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "subject_token": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "subject_token"
-                ]
-              }
-            }
+            "application/json": {}
           }
         },
         "responses": {

--- a/frontend/src/config/oidc.js
+++ b/frontend/src/config/oidc.js
@@ -17,7 +17,6 @@ const userStore = new WebStorageStateStore({ store: window.localStorage })
 const onSigninCallback = async (_user) => {
   window.history.replaceState({}, document.title, window.location.pathname)
   await onSigninComplete({
-    subjectToken: _user.access_token,
     dispatchEvent: true,
   })
 }

--- a/frontend/src/root.jsx
+++ b/frontend/src/root.jsx
@@ -42,7 +42,6 @@ const Root = () => {
         .signinSilent()
         .then(async (_user) => {
           await onSigninComplete({
-            subjectToken: _user.access_token,
             dispatchEvent: false,
           })
         })

--- a/frontend/src/services/api/index.js
+++ b/frontend/src/services/api/index.js
@@ -41,14 +41,12 @@ const getWorkspaces = async () => {
   return response.data
 }
 
-const exchangeToken = async ({ subjectToken }) => {
+const exchangeToken = async () => {
   const oidc = getPublicToken()
   const endpoint = `${API_URL}/auth/exchange-token/`
   const response = await axios.post(
     endpoint,
-    {
-      subject_token: subjectToken,
-    },
+    {},
     {
       headers: {
         Authorization: `${oidc.tokenType} ${oidc.accessToken}`,

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -1,10 +1,10 @@
 import { OIDC_CONFIDENTIAL_TOKEN_NS, EXCHANGED_TOKEN_EVT } from '../config/env'
 import API from '../services/api'
 
-const onSigninComplete = async ({ subjectToken, dispatchEvent }) => {
+const onSigninComplete = async ({ dispatchEvent }) => {
   // Now that we are authenticated within the public app
   // exchange the token with the confidential app
-  const apiToken = await API.auth.exchange({ subjectToken })
+  const apiToken = await API.auth.exchange()
   localStorage.setItem(OIDC_CONFIDENTIAL_TOKEN_NS, JSON.stringify(apiToken))
 
   if (dispatchEvent) {


### PR DESCRIPTION
- Since this endpoint is only accessible if the user sent the access
token in the Authorization header, we don't need to get the same token
from the request body. Removing it to avoid confusion in the future.