### PR TITLE
refactor: persist current selected workspace wheneve the root component re-mounts

### DIFF
--- a/frontend/src/root.jsx
+++ b/frontend/src/root.jsx
@@ -75,7 +75,10 @@ const Root = () => {
         })
     }
     if (auth.isAuthenticated && tokenExchanged) {
-      setSelectedWorkspace(getUserWorkspace())
+      // if the workspace is already set in localStorage
+      // we want to preserve that, since the user might have selected another workspace
+      const currentWorkspace = localStorage.getItem(OIDC_USER_WORKSPACE)
+      setSelectedWorkspace(currentWorkspace !== null ? currentWorkspace : getUserWorkspace())
       fetchWorkspaces()
     }
   }, [auth.isAuthenticated, tokenExchanged])


### PR DESCRIPTION
- If the user selects another workspace, we want to preserve his choice whenever he refreshes the page while his session is still connected