### PR TITLE
Improve file_downloader error handling + disable warnings/messages from third-party libraries

### DIFF
--- a/etl/python/common/dbs_client.py
+++ b/etl/python/common/dbs_client.py
@@ -3,6 +3,7 @@ import os
 import re
 
 import requests
+import urllib3
 from requests.exceptions import SSLError
 
 
@@ -42,8 +43,10 @@ class MinimalDBSClient:
             response = requests.get(url, params=params, cert=cert, timeout=TIMEOUT)
         except SSLError:
             # Running this curl request from LXPlus works without -k flag
-            # This is here for local testing
-            response = requests.get(url, params=params, cert=cert, timeout=TIMEOUT, verify=False)  # noqa: S501
+            # This is here for local testing and for Openshift deployment
+            with urllib3.warnings.catch_warnings():
+                urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+                response = requests.get(url, params=params, cert=cert, timeout=TIMEOUT, verify=False)  # noqa: S501
 
         response.raise_for_status()
         return response.json()

--- a/etl/python/common/lxplus_client.py
+++ b/etl/python/common/lxplus_client.py
@@ -52,10 +52,12 @@ class MinimalLXPlusClient:
         if return_code == 0:
             return out_fpath
         elif return_code == 124:
+            self.rm(out_fpath)
             raise XrdcpTimeoutError(
                 f"xrdcp (exit = {return_code}) timed out after {self.timeout} seconds for {grid_fpath}"
             )
         else:
+            self.rm(out_fpath)
             raise XrdcpUnknownError(f"xrdcp (exit = {return_code}) failed for {grid_fpath}. stderr: {stderr}")
 
     def scp(self, remote_fpath: str, local_fpath: str) -> str:
@@ -78,6 +80,10 @@ class MinimalLXPlusClient:
 
     def mkdir(self, remote_path: str) -> None:
         self.client.exec_command(f"mkdir -p {remote_path}")
+
+    def rm(self, remote_path: str, recursive: bool = False) -> None:
+        rm_base = "rm -rf" if recursive else "rm"
+        self.client.exec_command(f"{rm_base} {remote_path}")
 
     def __enter__(self) -> "MinimalLXPlusClient":
         return self

--- a/etl/python/common/lxplus_client.py
+++ b/etl/python/common/lxplus_client.py
@@ -1,3 +1,5 @@
+import logging
+
 import paramiko
 from scp import SCPClient
 
@@ -27,6 +29,8 @@ class MinimalLXPlusClient:
         self.client = paramiko.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         self.client.connect(self.SERVER, username=lxplus_user, password=lxplus_pwd)
+
+        logging.getLogger("paramiko").setLevel(logging.WARNING)
 
     def init_proxy(self) -> None:
         _, stdout, _ = self.client.exec_command(f"/usr/bin/timeout {self.timeout} voms-proxy-init -voms cms -rfc")

--- a/etl/python/common/lxplus_client.py
+++ b/etl/python/common/lxplus_client.py
@@ -3,25 +3,7 @@ import logging
 import paramiko
 from scp import SCPClient
 
-
-class SSHAuthenticationTimeoutError(Exception):
-    pass
-
-
-class SSHAuthenticationFailedError(Exception):
-    pass
-
-
-class XrdcpNoServersAvailableToReadFileError(Exception):
-    pass
-
-
-class XrdcpTimeoutError(Exception):
-    pass
-
-
-class XrdcpUnknownError(Exception):
-    pass
+from .lxplus_exceptions import XrdcpNoServersAvailableToReadFileError, XrdcpTimeoutError, XrdcpUnknownError
 
 
 class MinimalLXPlusClient:

--- a/etl/python/common/lxplus_client.py
+++ b/etl/python/common/lxplus_client.py
@@ -6,6 +6,9 @@ from scp import SCPClient
 from .lxplus_exceptions import XrdcpNoServersAvailableToReadFileError, XrdcpTimeoutError, XrdcpUnknownError
 
 
+logging.getLogger("paramiko").setLevel(logging.WARNING)
+
+
 class MinimalLXPlusClient:
     SERVER = "lxplus.cern.ch"
     ERROR_MSG_3011 = "[3011] No servers are available to read the file."
@@ -15,8 +18,6 @@ class MinimalLXPlusClient:
         self.client = paramiko.SSHClient()
         self.client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         self.client.connect(self.SERVER, username=lxplus_user, password=lxplus_pwd)
-
-        logging.getLogger("paramiko").setLevel(logging.WARNING)
 
     def init_proxy(self) -> None:
         _, stdout, _ = self.client.exec_command(f"/usr/bin/timeout {self.timeout} voms-proxy-init -voms cms -rfc")

--- a/etl/python/common/lxplus_client.py
+++ b/etl/python/common/lxplus_client.py
@@ -8,6 +8,10 @@ class SSHAuthenticationTimeoutError(Exception):
     pass
 
 
+class SSHAuthenticationFailedError(Exception):
+    pass
+
+
 class XrdcpNoServersAvailableToReadFileError(Exception):
     pass
 

--- a/etl/python/common/lxplus_exceptions.py
+++ b/etl/python/common/lxplus_exceptions.py
@@ -1,0 +1,18 @@
+class SSHAuthenticationTimeoutError(Exception):
+    pass
+
+
+class SSHAuthenticationFailedError(Exception):
+    pass
+
+
+class XrdcpNoServersAvailableToReadFileError(Exception):
+    pass
+
+
+class XrdcpTimeoutError(Exception):
+    pass
+
+
+class XrdcpUnknownError(Exception):
+    pass

--- a/etl/python/common/lxplus_exceptions.py
+++ b/etl/python/common/lxplus_exceptions.py
@@ -16,3 +16,7 @@ class XrdcpTimeoutError(Exception):
 
 class XrdcpUnknownError(Exception):
     pass
+
+
+class XrdcpBadRootFileError(Exception):
+    pass

--- a/etl/python/pipelines/file_downloader/extract.py
+++ b/etl/python/pipelines/file_downloader/extract.py
@@ -31,3 +31,4 @@ def extract(logical_file_name: str) -> None:
             return
         client.init_proxy()
         client.xrdcp(remote_landing_dir, logical_file_name)
+        client.validate_root(remote_landing_dir, logical_file_name)

--- a/etl/python/pipelines/file_downloader/pipeline.py
+++ b/etl/python/pipelines/file_downloader/pipeline.py
@@ -3,7 +3,11 @@ import traceback
 from paramiko.ssh_exception import AuthenticationException
 from sqlalchemy import create_engine
 
-from ...common.lxplus_client import SSHAuthenticationTimeoutError, XrdcpNoServersAvailableToReadFileError
+from ...common.lxplus_client import (
+    SSHAuthenticationFailedError,
+    SSHAuthenticationTimeoutError,
+    XrdcpNoServersAvailableToReadFileError,
+)
 from ...config import priority_era
 from ...env import conn_str
 from ...models.file_index import StatusCollection
@@ -29,6 +33,8 @@ def pipeline(
     except Exception as e:
         if isinstance(e, AuthenticationException) and "Authentication timeout" in str(e):
             raise SSHAuthenticationTimeoutError from e
+        elif isinstance(e, AuthenticationException) and "Authentication failed" in str(e):
+            raise SSHAuthenticationFailedError from e
         elif isinstance(e, XrdcpNoServersAvailableToReadFileError):
             err_status = StatusCollection.DOWNLOAD_FILE_NOT_AVAILABLE
         else:

--- a/etl/python/pipelines/file_downloader/pipeline.py
+++ b/etl/python/pipelines/file_downloader/pipeline.py
@@ -3,7 +3,7 @@ import traceback
 from paramiko.ssh_exception import AuthenticationException
 from sqlalchemy import create_engine
 
-from ...common.lxplus_client import (
+from ...common.lxplus_exceptions import (
     SSHAuthenticationFailedError,
     SSHAuthenticationTimeoutError,
     XrdcpNoServersAvailableToReadFileError,

--- a/etl/python/pipelines/file_downloader/tasks.py
+++ b/etl/python/pipelines/file_downloader/tasks.py
@@ -1,5 +1,5 @@
 from ...celery import app
-from ...common.lxplus_client import (
+from ...common.lxplus_exceptions import (
     SSHAuthenticationFailedError,
     SSHAuthenticationTimeoutError,
     XrdcpTimeoutError,

--- a/etl/python/pipelines/file_downloader/tasks.py
+++ b/etl/python/pipelines/file_downloader/tasks.py
@@ -1,11 +1,16 @@
 from ...celery import app
-from ...common.lxplus_client import SSHAuthenticationTimeoutError, XrdcpTimeoutError, XrdcpUnknownError
+from ...common.lxplus_client import (
+    SSHAuthenticationFailedError,
+    SSHAuthenticationTimeoutError,
+    XrdcpTimeoutError,
+    XrdcpUnknownError,
+)
 from .pipeline import pipeline
 
 
 @app.task(
     name="file_downloader_pipeline",
-    autoretry_for=(SSHAuthenticationTimeoutError, XrdcpTimeoutError, XrdcpUnknownError),
+    autoretry_for=(SSHAuthenticationTimeoutError, SSHAuthenticationFailedError, XrdcpTimeoutError, XrdcpUnknownError),
     retry_kwargs={"max_retries": 5},
     retry_backoff=True,
 )

--- a/etl/python/pipelines/file_downloader/tasks.py
+++ b/etl/python/pipelines/file_downloader/tasks.py
@@ -2,6 +2,7 @@ from ...celery import app
 from ...common.lxplus_exceptions import (
     SSHAuthenticationFailedError,
     SSHAuthenticationTimeoutError,
+    XrdcpBadRootFileError,
     XrdcpTimeoutError,
     XrdcpUnknownError,
 )
@@ -10,7 +11,13 @@ from .pipeline import pipeline
 
 @app.task(
     name="file_downloader_pipeline",
-    autoretry_for=(SSHAuthenticationTimeoutError, SSHAuthenticationFailedError, XrdcpTimeoutError, XrdcpUnknownError),
+    autoretry_for=(
+        SSHAuthenticationTimeoutError,
+        SSHAuthenticationFailedError,
+        XrdcpTimeoutError,
+        XrdcpUnknownError,
+        XrdcpBadRootFileError,
+    ),
     retry_kwargs={"max_retries": 5},
     retry_backoff=True,
 )

--- a/etl/python/pipelines/file_ingesting/extract.py
+++ b/etl/python/pipelines/file_ingesting/extract.py
@@ -8,6 +8,36 @@ from ...env import eos_landing_zone, lxplus_pwd, lxplus_user, mounted_eos_path
 from ..utils import clean_file
 
 
+def extract_locally(primary_dataset: str, file_name: str, target_fpath: str) -> None:
+    local_landing_dir = os.path.join(mounted_eos_path, primary_dataset)
+    local_file_path = os.path.join(local_landing_dir, file_name)
+
+    try:
+        shutil.copy(local_file_path, target_fpath)
+    except FileNotFoundError:
+        # If your are trying to ingest a file that is not mounted locally
+        # or is not in the samples directory, we can copy it from lxplus here
+        extract_through_lxplus(primary_dataset, file_name, local_file_path)
+        extract_locally(primary_dataset, file_name, target_fpath)
+    except Exception as e:
+        if os.path.isfile(target_fpath):
+            clean_file(target_fpath)
+        raise e
+
+
+def extract_through_lxplus(primary_dataset: str, file_name: str, target_fpath: str) -> None:
+    remote_landing_dir = os.path.join(eos_landing_zone, primary_dataset)
+    remote_file_path = os.path.join(remote_landing_dir, file_name)
+
+    with MinimalLXPlusClient(lxplus_user, lxplus_pwd) as client:
+        try:
+            client.scp(remote_file_path, target_fpath)
+        except Exception as e:
+            if os.path.isfile(target_fpath):
+                clean_file(target_fpath)
+            raise e
+
+
 def extract(logical_file_name: str) -> str:
     """
     Extracts a DQMIO file from EOS and returns the local path to the extracted file.
@@ -20,24 +50,9 @@ def extract(logical_file_name: str) -> str:
 
     # Download the file to tmp_fpath
     if mounted_eos_path and os.path.isdir(mounted_eos_path):
-        local_landing_dir = os.path.join(mounted_eos_path, primary_dataset)
-        local_file_path = os.path.join(local_landing_dir, file_name)
-        try:
-            shutil.copy(local_file_path, tmp_fpath)
-        except Exception as e:
-            if os.path.isfile(tmp_fpath):
-                clean_file(tmp_fpath)
-            raise e
+        extract_locally(primary_dataset, file_name, tmp_fpath)
     else:
-        remote_landing_dir = os.path.join(eos_landing_zone, primary_dataset)
-        remote_file_path = os.path.join(remote_landing_dir, file_name)
-        with MinimalLXPlusClient(lxplus_user, lxplus_pwd) as client:
-            try:
-                client.scp(remote_file_path, tmp_fpath)
-            except Exception as e:
-                if os.path.isfile(tmp_fpath):
-                    clean_file(tmp_fpath)
-                raise e
+        extract_through_lxplus(primary_dataset, file_name, tmp_fpath)
 
     # Well... if the previous function succeeded we should find the file locally in tmp_fpath.
     if os.path.isfile(tmp_fpath) is False:


### PR DESCRIPTION
- Disable SSL warnings when requesting DBS outside LXPLus;
- Set `paramiko` logger level to WARNING;
- Move `lxplus_client.py` custom exceptions to a dedicated script;
- Remove leftover file from EOS area if `xrdcp` fails from timeout or an unknown error;
- Check if root file is not corrupted through `ssh` using LXPLus ROOT installation after downloading file using `xrdcp`;
- Retry `file_downloader` pipeline if `XrdcpBadRootFileError` or `SSHAuthenticationFailedError` are raised.