### PR TITLE
fix: auto resize plots generated inside 0 height div

### DIFF
--- a/frontend/src/components/responsivePlot.jsx
+++ b/frontend/src/components/responsivePlot.jsx
@@ -1,22 +1,26 @@
 import React from 'react'
 
 import Plot from 'react-plotly.js'
+import { useResizeDetector } from 'react-resize-detector'
 import Spinner from 'react-bootstrap/Spinner'
 
 const ResponsivePlot = (props) => {
+  const { width, height, ref } = useResizeDetector({})
   const { data, layout, config, style, isLoading } = props
   return (
     <>
       {isLoading ? (
         <Spinner animation='border' role='status' />
       ) : (
-        <Plot
-          data={data}
-          layout={layout}
-          config={config}
-          useResizeHandler={true}
-          style={style}
-        />
+        <div ref={ref} style={{ display: 'flex', height: '100%' }}>
+          <Plot
+            data={data}
+            layout={{...layout, width, height}}
+            config={config}
+            useResizeHandler={true}
+            style={style}
+          />
+        </div>
       )}
     </>
   )

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^18.2.0",
     "react-oidc-context": "^3.0.0",
     "react-plotly.js": "^2.6.0",
+    "react-resize-detector": "^11.0.1",
     "react-router-dom": "^6.21.3",
     "react-toastify": "^10.0.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,7 +3280,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.15:
+lodash@^4.17.15, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3922,6 +3922,13 @@ react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
+react-resize-detector@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-11.0.1.tgz#70684958ae82bc0deb240d133a1ee440e0624532"
+  integrity sha512-1Tdgu6Ou3vI3RQD+o2/kTvDibb4NRe7Oh83hIjNNEXb6WKKCQT99VQlh3Xlbdq2HtkUoFEMrgMMKkYI83YbD7Q==
+  dependencies:
+    lodash "^4.17.21"
 
 react-router-dom@^6.21.3:
   version "6.22.3"


### PR DESCRIPTION
- ResponsivePlots rendered inside `lumisection` page Accordion gets rendered with wrong initial height and width since accordion items body is initially hidden. Adding `react-resize-detector` the plot container geits automatically scaled when the accordion item is expanded.