### PR TITLE
feat: add oms proxy endpoint

### DIFF
--- a/backend/dials/settings.py
+++ b/backend/dials/settings.py
@@ -168,6 +168,10 @@ KEYCLOAK_CONFIDENTIAL_SECRET_KEY = config("DJANGO_KEYCLOAK_CONFIDENTIAL_SECRET_K
 KEYCLOAK_PUBLIC_CLIENT_ID = config("DJANGO_KEYCLOAK_PUBLIC_CLIENT_ID")
 KEYCLOAK_API_CLIENTS = json.loads(config("DJANGO_KEYCLOAK_API_CLIENTS", default="{}"))
 
+# OMS OIDC
+OMS_SSO_CLIENT_ID = config("DJANGO_OMS_SSO_CLIENT_ID")
+OMS_SSO_CLIENT_SECRET = config("DJANGO_OMS_SSO_CLIENT_SECRET")
+
 # All available policies are listed at:
 # https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
 # Empty list means the policy is disabled

--- a/backend/dials/urls.py
+++ b/backend/dials/urls.py
@@ -5,6 +5,7 @@ from django.urls import include, path
 from django.views.generic import TemplateView
 from file_index.routers import router as file_index_router
 from lumisection.routers import router as lumisection_router
+from oms_proxy.routers import router as oms_proxy_router
 from rest_framework import routers
 from run.routers import router as run_router
 from th1.routers import router as th1_router
@@ -20,6 +21,7 @@ router.registry.extend(lumisection_router.registry)
 router.registry.extend(th1_router.registry)
 router.registry.extend(th2_router.registry)
 router.registry.extend(cern_auth_router.registry)
+router.registry.extend(oms_proxy_router.registry)
 
 swagger_view = TemplateView.as_view(template_name="swagger-ui.html", extra_context={"schema_url": "openapi-schema"})
 

--- a/backend/oms_proxy/apps.py
+++ b/backend/oms_proxy/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class OMSProxyConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "oms_proxy"

--- a/backend/oms_proxy/client.py
+++ b/backend/oms_proxy/client.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta
+
+import requests
+import urllib3
+from django.conf import settings
+from utils.rest_framework_cern_sso.backends import CERNKeycloakOIDC
+
+
+class SimpleOMSClient:
+    OMS_API_URL = "https://cmsoms.cern.ch/agg/api/v1"
+    OMS_AUDIENCE = "cmsoms-prod"
+
+    def __init__(self, timeout: int = 30):
+        self.timeout = timeout
+        self.kc = CERNKeycloakOIDC(
+            skip_pk=True,
+            server_url=settings.KEYCLOAK_SERVER_URL,
+            realm_name=settings.KEYCLOAK_REALM,
+            client_id=settings.OMS_SSO_CLIENT_ID,
+            client_secret_key=settings.OMS_SSO_CLIENT_SECRET,
+        )
+        self.auth = None
+        self.expires_at = None
+
+    def __auth(self):
+        token = self.kc.issue_api_token(aud=self.OMS_AUDIENCE)
+        self.expires_at = datetime.now() + timedelta(seconds=token["expires_in"])
+        self.auth = f"{token['token_type']} {token['access_token']}"
+
+    def __is_expired(self):
+        if self.expires_at is None:
+            return True
+        return (self.expires_at - timedelta(seconds=15)) < datetime.now()
+
+    def __build_headers(self):
+        if self.__is_expired():
+            self.__auth()
+        return {"Authorization": self.auth, "Content-type": "application/json"}
+
+    def query(self, endpoint: str, **kwargs):
+        headers = self.__build_headers()
+
+        # Running this curl request from LXPlus works without -k flag
+        # This is here to avoid double requesting OMS
+        # since the application is deployed in Openshift
+        with urllib3.warnings.catch_warnings():
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            response = requests.get(
+                f"{self.OMS_API_URL}/{endpoint}",
+                headers=headers,
+                timeout=self.timeout,
+                verify=False,  # noqa: S501
+                **kwargs,
+            )
+
+        response.raise_for_status()
+        return response.json()

--- a/backend/oms_proxy/routers.py
+++ b/backend/oms_proxy/routers.py
@@ -1,0 +1,7 @@
+from rest_framework import routers
+
+from .viewsets import OMSProxyViewSet
+
+
+router = routers.SimpleRouter()
+router.register(r"oms-proxy", OMSProxyViewSet, basename="oms-proxy")

--- a/backend/oms_proxy/viewsets.py
+++ b/backend/oms_proxy/viewsets.py
@@ -1,0 +1,25 @@
+from typing import ClassVar
+
+from rest_framework import viewsets
+from rest_framework.authentication import BaseAuthentication
+from rest_framework.response import Response
+from utils.rest_framework_cern_sso.authentication import (
+    CERNKeycloakClientSecretAuthentication,
+    CERNKeycloakConfidentialAuthentication,
+)
+
+from .client import SimpleOMSClient
+
+
+class OMSProxyViewSet(viewsets.ViewSet):
+    oms = SimpleOMSClient()
+    authentication_classes: ClassVar[list[BaseAuthentication]] = [
+        CERNKeycloakClientSecretAuthentication,
+        CERNKeycloakConfidentialAuthentication,
+    ]
+
+    def list(self, request):
+        params = dict(request.query_params)
+        endpoint = params.pop("endpoint")[0]
+        response = self.oms.query(endpoint, params=params)
+        return Response(response)

--- a/backend/static/swagger.json
+++ b/backend/static/swagger.json
@@ -1919,7 +1919,79 @@
           {}
         ]
       }
-    }
+    },
+    "/api/v1/oms-proxy/": {
+      "get": {
+        "operationId": "proxyOMS",
+        "description": "Proxy request to OMS API",
+        "parameters": [
+          {
+            "name": "endpoint",
+            "required": true,
+            "in": "query",
+            "description": "OMS API endpoint such as (runs, lumisections, datasetrates and etc)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "required": true,
+            "in": "query",
+            "description": "OMS API endpoint filters",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true,
+              "example": {
+                "run_number": 382921,
+                "dataset_name": "ZeroBias"
+              }
+            },
+            "style": "deepObject"
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "OMS API endpoint page configuration",
+            "schema": {
+              "type": "object",
+              "additionalProperties": true,
+              "example": {
+                "limit": 10,
+              }
+            },
+            "style": "deepObject"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "OMSProxy"
+        ],
+        "security": [
+          {
+            "Client Secret Key": []
+          },
+          {
+            "Confidential JWT Token": []
+          },
+          {}
+        ]
+      }
+    },
   },
   "components": {
     "schemas": {

--- a/backend/utils/rest_framework_cern_sso/backends.py
+++ b/backend/utils/rest_framework_cern_sso/backends.py
@@ -25,14 +25,14 @@ class CERNKeycloakOIDC:
     def issue_device_token(self, device_code: str) -> dict:
         return self._kc.token(grant_type="urn:ietf:params:oauth:grant-type:device_code", device_code=device_code)
 
-    def issue_api_token(self) -> dict:
+    def issue_api_token(self, aud: str | None = None) -> dict:
         response = requests.post(
             f"{self.server_url}realms/{self.realm_name}/api-access/token",
             data={
                 "grant_type": "client_credentials",
                 "client_id": self.client_id,
                 "client_secret": self.client_secret_key,
-                "audience": self.client_id,
+                "audience": aud or self.client_id,
             },
             timeout=30,
         )


### PR DESCRIPTION
- Accept custom audience in `rest_framework_cern_sso.backends.issue_api_token` method, so we can generate correct credentials for OMS api too;
- Add OMS proxy endpoint resources.