### PR TITLE
refactor: replace docker.io nginx-unprivileged and upload it directly to harbor

### DIFF
--- a/oc/prod/deployments/web/backend.yaml
+++ b/oc/prod/deployments/web/backend.yaml
@@ -58,7 +58,7 @@ spec:
               mountPath: /var/www/api/
               readOnly: true
           imagePullPolicy: Always
-          image: nginxinc/nginx-unprivileged
+          image: image-registry.openshift-image-registry.svc:5000/cms-dials-prod/nginx-unprivileged:latest
       volumes:
         - name: nginx-conf
           configMap:

--- a/oc/prod/image_stream.yaml
+++ b/oc/prod/image_stream.yaml
@@ -53,3 +53,22 @@ spec:
         name: registry.cern.ch/cms-dqmdc/dials-frontend
       referencePolicy:
         type: Local
+
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: nginx-unprivileged
+  namespace: cms-dials-prod
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      annotations:
+        openshift.io/imported-from: registry.cern.ch/cms-dqmdc/nginxinc-nginx-unprivileged
+      from:
+        kind: DockerImage
+        name: registry.cern.ch/cms-dqmdc/nginxinc-nginx-unprivileged
+      referencePolicy:
+        type: Local

--- a/scripts/import_images_to_oc.sh
+++ b/scripts/import_images_to_oc.sh
@@ -9,3 +9,4 @@ check_oc_project
 oc import-image etl --from=registry.cern.ch/cms-dqmdc/dials-etl --confirm
 oc import-image backend --from=registry.cern.ch/cms-dqmdc/dials-backend --confirm
 oc import-image frontend --from=registry.cern.ch/cms-dqmdc/dials-frontend --confirm
+oc import-image nginx-unprivileged --from=registry.cern.ch/cms-dqmdc/nginxinc-nginx-unprivileged --confirm

--- a/scripts/push_containers.sh
+++ b/scripts/push_containers.sh
@@ -6,14 +6,17 @@ REGISTRY_REPO=registry.cern.ch/cms-dqmdc
 docker build -f ./etl/Dockerfile.prod -t dials_etl_release .
 docker build -f ./backend/Dockerfile -t dials_backend_release .
 docker build -f ./frontend/Dockerfile.prod -t dials_frontend_release .
+docker pull nginxinc/nginx-unprivileged
 
 # Tag containers according to remote registry
 docker tag dials_etl_release $REGISTRY_REPO/dials-etl
 docker tag dials_backend_release $REGISTRY_REPO/dials-backend
 docker tag dials_frontend_release $REGISTRY_REPO/dials-frontend
+docker tag nginxinc/nginx-unprivileged:latest $REGISTRY_REPO/nginxinc-nginx-unprivileged
 
 # Login to registry and push containers
 docker login https://registry.cern.ch
 docker push $REGISTRY_REPO/dials-etl
 docker push $REGISTRY_REPO/dials-backend
 docker push $REGISTRY_REPO/dials-frontend
+docker push $REGISTRY_REPO/nginxinc-nginx-unprivileged


### PR DESCRIPTION
- This is done to avoid DockerHub's rate limits when rolling out new
versions of the backend.