### PR TITLE
bump: requests from 2.31.0 to 2.32.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2125,13 +2125,13 @@ ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]
@@ -2494,4 +2494,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5e5be827f5649906d1e7d39fc916e03facd7dba689a6b34d93860dea1401bf89"
+content-hash = "2edbbf1dbf6a0a24274d1a8cd25980f7e84aae50d9fccd05767aebb225050785"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 python = "^3.10"
 python-decouple = "^3.8"
 psycopg2-binary = "^2.9.9"
-requests = "^2.31.0"
+requests = "^2.32.0"
 
 [tool.poetry.group.backend.dependencies]
 django = "^5.0.6"


### PR DESCRIPTION
- Fixes dependabot#22, requiring requests@^2.32.0