### PR TITLE
fix: dependabot #22 and #26

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -782,18 +782,17 @@ hiredis = ["redis[hiredis] (>=3,!=4.0.0,!=4.0.1)"]
 
 [[package]]
 name = "djangorestframework"
-version = "3.14.0"
+version = "3.15.2"
 description = "Web APIs for Django, made easy."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "djangorestframework-3.14.0-py3-none-any.whl", hash = "sha256:eb63f58c9f218e1a7d064d17a70751f528ed4e1d35547fdade9aaf4cd103fd08"},
-    {file = "djangorestframework-3.14.0.tar.gz", hash = "sha256:579a333e6256b09489cbe0a067e66abe55c6595d8926be6b99423786334350c8"},
+    {file = "djangorestframework-3.15.2-py3-none-any.whl", hash = "sha256:2b8871b062ba1aefc2de01f773875441a961fefbf79f5eed1e32b2f096944b20"},
+    {file = "djangorestframework-3.15.2.tar.gz", hash = "sha256:36fe88cd2d6c6bec23dca9804bab2ba5517a8bb9d8f47ebc68981b56840107ad"},
 ]
 
 [package.dependencies]
-django = ">=3.0"
-pytz = "*"
+django = ">=4.2"
 
 [[package]]
 name = "filelock"
@@ -2125,13 +2124,13 @@ ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"
 
 [[package]]
 name = "requests"
-version = "2.31.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
-    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]
@@ -2494,4 +2493,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "db934c183281b21ce3cd8167327371f4c90115a6799467b246e9a1d082922cc9"
+content-hash = "87cacb543127ff9099b647aa3b09aadc5a148e39ab1f57aae459a4d9e38d7d04"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,11 @@ readme = "README.md"
 python = "^3.10"
 python-decouple = "^3.8"
 psycopg2-binary = "^2.9.9"
-requests = "^2.31.0"
+requests = "^2.32.0"
 
 [tool.poetry.group.backend.dependencies]
 django = "5.0.8"
-djangorestframework = "^3.14.0"
+djangorestframework = "^3.15.2"
 django-filter = "^23.5"
 django-cors-headers = "^4.3.1"
 django-debreach = "^2.1.0"


### PR DESCRIPTION
- Bump requests from 2.31.0 to 2.32.3
- Bump djangorestframework from 3.14.0 to 3.15.2