### PR TITLE
fix: unsorted golden json in ml-bad-lumisection endpoint

### DIFF
--- a/backend/ml_bad_lumisection/viewsets.py
+++ b/backend/ml_bad_lumisection/viewsets.py
@@ -94,7 +94,7 @@ class MLBadLumisectionViewSet(GenericViewSetRouter, mixins.ListModelMixin, views
         result = (
             queryset.filter(dataset_id__in=dataset_id__in, run_number__in=run_number__in, model_id__in=model_id__in)
             .all()
-            .order_by("run_number", "ls_number")
+            .order_by("dataset_id", "run_number", "ls_number")
             .values()
         )
         result = [qs for qs in result]
@@ -150,6 +150,7 @@ class MLBadLumisectionViewSet(GenericViewSetRouter, mixins.ListModelMixin, views
                 Lumisection.objects.using(workspace)
                 .filter(dataset_id__in=dataset_id__in, run_number=run_number)
                 .all()
+                .order_by("ls_number")
                 .values_list("ls_number", flat=True)
             )
             good_lumis = [ls for ls in all_lumis if ls not in bad_lumis]

--- a/backend/utils/common.py
+++ b/backend/utils/common.py
@@ -2,6 +2,7 @@ import itertools
 
 
 def list_to_range(i):
-    for _, b in itertools.groupby(enumerate(i), lambda pair: pair[1] - pair[0]):
+    _i = sorted(i)
+    for _, b in itertools.groupby(enumerate(_i), lambda pair: pair[1] - pair[0]):
         b = list(b)
         yield b[0][1], b[-1][1]


### PR DESCRIPTION
- The generated golden json wasn't ordering the Lumisection's query by the `ls_number` and the `list_to_range` routine was also not ordering the input list. Consequently, the generated golden json had unsorted ranges with gaps that looked like bad lumisections.