### PR TITLE
fix: small fixes in scripts in etl cli

### DIFF
--- a/etl/cli.py
+++ b/etl/cli.py
@@ -45,7 +45,7 @@ def get_files_by_status(workspace: str, status: str | list[str]) -> None:
 def ingesting_handler(args):
     if args.all and args.status is None:
         raise ValueError("status argument should be defined when --all is used")
-    if StatusCollection.FINISHED in args.status and args.me_startswith is None:
+    if args.all and StatusCollection.FINISHED in args.status and args.me_startswith is None:
         raise ValueError("me_startswith should be set if status is FINISHED")
 
     workspace = next(filter(lambda x: x["name"] == args.workspace, WORKSPACES), None)

--- a/scripts/ssh_to_common_indexer.sh
+++ b/scripts/ssh_to_common_indexer.sh
@@ -6,7 +6,7 @@ source "$(dirname "$0")/utils.sh"
 check_oc_project
 
 # Select pod
-POD_NAME=$(get_pod_name "redis-etl-broker")
+POD_NAME=$(get_pod_name "common-indexer")
 echo -e "Selected pod: ${POD_NAME}\n"
 
 # "SSH" to container in the pod


### PR DESCRIPTION
- Only check the `args.status` and `args.me_startswith` in `ingesting_handler` when `args.all` is true.
- Get pode name for string `common-indexer` instead of `redis-etl-broker` in `ssh_to_common_indexer.sh`.